### PR TITLE
Make Tree Ring Memory Rust-first by default

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -710,6 +710,7 @@ version = "0.3.0"
 dependencies = [
  "pyo3",
  "pyo3-build-config",
+ "serde",
  "serde_json",
  "tempfile",
  "tree-ring-memory-core",

--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ framework-agnostic and does not replace either protocol.
 Tree Ring Memory is in protocol-preview status.
 
 - v0.1 provides a local Python reference library with SQLite storage and no required cloud services.
-- v0.2 is moving durable behavior into a Rust core while preserving Python compatibility.
-- v0.3 starts a PyO3 native binding path through explicit `NativeTreeRingMemory`; the default Python facade has not switched yet.
+- v0.2 moved durable behavior into a Rust core while preserving Python compatibility.
+- v0.3 makes the public Python facade Rust-first when the optional PyO3 native module is installed.
 
 The Rust workspace currently includes:
 
@@ -26,24 +26,26 @@ The Rust workspace currently includes:
 - `crates/tree-ring-memory-sqlite`: schema-compatible SQLite/FTS storage and recall filtering.
 - `crates/tree-ring-memory-cli`: native `tree-ring` CLI.
 
-Python remains the stable public API while Rust parity expands.
+Python remains the stable public API surface, but Rust is the authoritative
+engine when the native module is installed. Source checkouts without the native
+extension fall back to the explicit `PythonTreeRingMemory` reference backend
+unless `TREE_RING_MEMORY_REQUIRE_NATIVE=1` or `TREE_RING_MEMORY_BACKEND=native`
+is set.
 
 Python can also exercise the Rust-backed path explicitly through
 `RustCliTreeRingMemory`. This bridge uses the native Rust CLI and returns the
 same Python model object shapes, but it is intentionally limited in v0.2:
 `remember` supports summary, event type, ring, scope, project, and tags; `recall`
 supports query, project, limit, and sensitive-memory inclusion. Unsupported
-Python facade fields fail explicitly instead of being silently ignored. Full
-parity for the default PyO3-backed Python facade and richer CLI flags remain
-planned.
+Python facade fields fail explicitly instead of being silently ignored.
 
-`NativeTreeRingMemory` is the v0.3 native preview. It requires the optional PyO3
-module and is intentionally explicit:
+`NativeTreeRingMemory` is the explicit Rust-native backend. `TreeRingMemory`
+uses the same backend automatically when the optional PyO3 module is installed:
 
 ```python
-from tree_ring_memory import NativeTreeRingMemory
+from tree_ring_memory import TreeRingMemory
 
-memory = NativeTreeRingMemory.open(".tree-ring")
+memory = TreeRingMemory.open(".tree-ring")
 event = memory.remember(summary="Native Rust path works.", event_type="lesson")
 results = memory.recall("Rust path")
 ```
@@ -59,6 +61,15 @@ maturin develop
 The native binding package is extension-only. It does not package or own the
 public `tree_ring_memory` Python package; install the main package separately in
 the same environment.
+
+Backend selection:
+
+- `TREE_RING_MEMORY_BACKEND=auto` uses native Rust when available and otherwise
+  falls back to the Python reference backend.
+- `TREE_RING_MEMORY_BACKEND=native` or `TREE_RING_MEMORY_REQUIRE_NATIVE=1`
+  requires Rust native bindings and fails if they are missing.
+- `TREE_RING_MEMORY_BACKEND=python` forces the reference backend for parity
+  testing or troubleshooting.
 
 For the CLI bridge, set `TREE_RING_MEMORY_CLI=/path/to/tree-ring` to use a
 prebuilt binary. If unset, the bridge looks for `tree-ring` on `PATH` and falls

--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -12,6 +12,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 pyo3.workspace = true
+serde.workspace = true
 serde_json.workspace = true
 tree-ring-memory-core = { path = "../../crates/tree-ring-memory-core" }
 tree-ring-memory-sqlite = { path = "../../crates/tree-ring-memory-sqlite" }

--- a/bindings/python/README.md
+++ b/bindings/python/README.md
@@ -1,6 +1,6 @@
 # Tree Ring Memory Native Python Binding
 
-This package builds only the optional PyO3 extension module:
+This package builds only the PyO3 extension module:
 
 ```text
 tree_ring_memory._tree_ring_memory_native
@@ -9,6 +9,10 @@ tree_ring_memory._tree_ring_memory_native
 It intentionally does not package `../../src` or own the public
 `tree_ring_memory` Python package. Install the main package separately, then
 install this native extension into the same environment.
+
+When installed, the public `TreeRingMemory.open()` facade uses this Rust-native
+backend by default. Without it, source checkouts fall back to the Python
+reference backend unless native mode is required by environment configuration.
 
 Development build:
 

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -1,8 +1,9 @@
 use pyo3::exceptions::{PyRuntimeError, PyValueError};
 use pyo3::prelude::*;
+use serde::Deserialize;
 use std::path::PathBuf;
 use tree_ring_memory_core::sensitivity::SensitivityGuard;
-use tree_ring_memory_core::MemoryEvent;
+use tree_ring_memory_core::{MemoryEvent, MemoryLink, MemoryReview, MemorySource};
 use tree_ring_memory_sqlite::{MemoryRetriever, SQLiteMemoryStore};
 
 #[pyclass(name = "TreeRingMemoryNative", unsendable)]
@@ -61,22 +62,43 @@ impl PyTreeRingMemoryNative {
         if detected_sensitivity != "normal" {
             event.sensitivity = detected_sensitivity;
         }
-        event.validate().map_err(to_py_value_error)?;
-        self.store.put(&event).map_err(to_py_runtime_error)?;
-        serde_json::to_string(&event).map_err(to_py_runtime_error)
+        self.put_event(event)
+    }
+
+    pub fn remember_event_json(&mut self, request_json: &str) -> PyResult<String> {
+        let request: RememberRequest =
+            serde_json::from_str(request_json).map_err(to_py_value_error)?;
+        let mut event =
+            MemoryEvent::new(request.summary, request.event_type).map_err(to_py_value_error)?;
+        event.scope = request.scope.unwrap_or_else(|| "global".to_string());
+        event.ring = request.ring.unwrap_or_else(|| "cambium".to_string());
+        event.project = request.project;
+        event.agent_profile = request.agent_profile;
+        event.details = request.details.unwrap_or_default();
+        event.source = request.source.unwrap_or_default();
+        event.tags = request.tags.unwrap_or_default();
+        if let Some(salience) = request.salience {
+            event.salience = salience;
+        }
+        if let Some(confidence) = request.confidence {
+            event.confidence = confidence;
+        }
+        if let Some(sensitivity) = request.sensitivity {
+            event.sensitivity = sensitivity;
+        }
+        if let Some(retention) = request.retention {
+            event.retention = retention;
+        }
+        event.expires_at = request.expires_at;
+        event.supersedes = request.supersedes.unwrap_or_default();
+        event.links = request.links.unwrap_or_default();
+        event.review = request.review.unwrap_or_default();
+        self.put_event(event)
     }
 
     pub fn put_event_json(&mut self, event_json: &str) -> PyResult<String> {
-        let mut event: MemoryEvent = serde_json::from_str(event_json).map_err(to_py_value_error)?;
-        let detected_sensitivity = SensitivityGuard::default()
-            .detect_memory_event_sensitivity(&event)
-            .map_err(to_py_value_error)?;
-        if event.sensitivity == "normal" && detected_sensitivity != "normal" {
-            event.sensitivity = detected_sensitivity;
-        }
-        event.validate().map_err(to_py_value_error)?;
-        self.store.put(&event).map_err(to_py_runtime_error)?;
-        serde_json::to_string(&event).map_err(to_py_runtime_error)
+        let event: MemoryEvent = serde_json::from_str(event_json).map_err(to_py_value_error)?;
+        self.put_event(event)
     }
 
     #[pyo3(signature = (query, project=None, limit=8, include_sensitive=false))]
@@ -114,6 +136,36 @@ impl PyTreeRingMemoryNative {
         serde_json::to_string(&payload).map_err(to_py_runtime_error)
     }
 
+    pub fn recall_query_json(&self, request_json: &str) -> PyResult<String> {
+        let request: RecallRequest =
+            serde_json::from_str(request_json).map_err(to_py_value_error)?;
+        let results = MemoryRetriever::new(&self.store)
+            .recall(
+                &request.query,
+                request.project.as_deref(),
+                request.agent_profile.as_deref(),
+                request.scope.as_deref(),
+                request.rings.as_deref(),
+                request.event_types.as_deref(),
+                request.include_sensitive.unwrap_or(false),
+                request.include_superseded.unwrap_or(false),
+                request.limit.unwrap_or(8),
+                request.explain_ranking.unwrap_or(false),
+            )
+            .map_err(to_py_runtime_error)?;
+        let payload: Vec<_> = results
+            .into_iter()
+            .map(|result| {
+                serde_json::json!({
+                    "memory": result.memory,
+                    "score": result.score,
+                    "ranking": result.ranking,
+                })
+            })
+            .collect();
+        serde_json::to_string(&payload).map_err(to_py_runtime_error)
+    }
+
     pub fn forget(&mut self, memory_id: String, mode: String, reason: String) -> PyResult<()> {
         if reason.trim().is_empty() {
             return Err(PyValueError::new_err("forget reason is required"));
@@ -126,6 +178,84 @@ impl PyTreeRingMemoryNative {
             ))),
         }
     }
+}
+
+impl PyTreeRingMemoryNative {
+    fn put_event(&mut self, mut event: MemoryEvent) -> PyResult<String> {
+        let detected_sensitivity = SensitivityGuard::default()
+            .detect_memory_event_sensitivity(&event)
+            .map_err(to_py_value_error)?;
+        if event.sensitivity == "normal" && detected_sensitivity != "normal" {
+            event.sensitivity = detected_sensitivity;
+        }
+        event.validate().map_err(to_py_value_error)?;
+        self.store.put(&event).map_err(to_py_runtime_error)?;
+        for superseded_id in &event.supersedes {
+            self.store
+                .supersede(superseded_id, &event.id)
+                .map_err(to_py_runtime_error)?;
+        }
+        serde_json::to_string(&event).map_err(to_py_runtime_error)
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct RememberRequest {
+    summary: String,
+    event_type: String,
+    #[serde(default)]
+    scope: Option<String>,
+    #[serde(default)]
+    ring: Option<String>,
+    #[serde(default)]
+    project: Option<String>,
+    #[serde(default)]
+    agent_profile: Option<String>,
+    #[serde(default)]
+    details: Option<String>,
+    #[serde(default)]
+    source: Option<MemorySource>,
+    #[serde(default)]
+    tags: Option<Vec<String>>,
+    #[serde(default)]
+    salience: Option<f64>,
+    #[serde(default)]
+    confidence: Option<f64>,
+    #[serde(default)]
+    sensitivity: Option<String>,
+    #[serde(default)]
+    retention: Option<String>,
+    #[serde(default)]
+    expires_at: Option<String>,
+    #[serde(default)]
+    supersedes: Option<Vec<String>>,
+    #[serde(default)]
+    links: Option<Vec<MemoryLink>>,
+    #[serde(default)]
+    review: Option<MemoryReview>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RecallRequest {
+    query: String,
+    #[serde(default)]
+    project: Option<String>,
+    #[serde(default)]
+    agent_profile: Option<String>,
+    #[serde(default)]
+    scope: Option<String>,
+    #[serde(default)]
+    rings: Option<Vec<String>>,
+    #[serde(default)]
+    event_types: Option<Vec<String>>,
+    #[serde(default)]
+    include_sensitive: Option<bool>,
+    #[serde(default)]
+    include_superseded: Option<bool>,
+    #[serde(default)]
+    limit: Option<usize>,
+    #[serde(default)]
+    explain_ranking: Option<bool>,
 }
 
 #[pyfunction]
@@ -203,6 +333,161 @@ mod tests {
 
         assert!(event.id.starts_with("mem_"));
         assert!(recalled_json.contains(&event.id));
+    }
+
+    #[test]
+    fn native_binding_remember_event_json_preserves_full_facade_contract() {
+        pyo3::prepare_freethreaded_python();
+        let dir = tempdir().unwrap();
+        let mut memory =
+            PyTreeRingMemoryNative::open(dir.path().join(".tree-ring").display().to_string())
+                .unwrap();
+        let request = serde_json::json!({
+            "summary": "Rust owns the full remember contract.",
+            "details": "Details should be stored natively.",
+            "event_type": "decision",
+            "scope": "project",
+            "ring": "heartwood",
+            "project": "migration",
+            "agent_profile": "default",
+            "source": {"type": "file", "ref": "README.md", "quote": ""},
+            "tags": ["rust", "native"],
+            "salience": 0.8,
+            "confidence": 0.9,
+            "retention": "durable",
+            "links": [{"type": "file", "target": "README.md"}],
+            "review": {"needs_review": true, "review_reason": "native parity"}
+        });
+
+        let event_json = memory
+            .remember_event_json(&serde_json::to_string(&request).unwrap())
+            .unwrap();
+        let event: MemoryEvent = serde_json::from_str(&event_json).unwrap();
+
+        assert_eq!(event.summary, "Rust owns the full remember contract.");
+        assert_eq!(event.details, "Details should be stored natively.");
+        assert_eq!(event.scope, "project");
+        assert_eq!(event.ring, "heartwood");
+        assert_eq!(event.project.as_deref(), Some("migration"));
+        assert_eq!(event.agent_profile.as_deref(), Some("default"));
+        assert_eq!(event.source.ref_, "README.md");
+        assert_eq!(event.tags, vec!["rust".to_string(), "native".to_string()]);
+        assert_eq!(event.salience, 0.8);
+        assert_eq!(event.confidence, 0.9);
+        assert_eq!(event.retention, "durable");
+        assert_eq!(event.links[0].target, "README.md");
+        assert!(event.review.needs_review);
+    }
+
+    #[test]
+    fn native_binding_remember_event_json_supersedes_prior_memory() {
+        pyo3::prepare_freethreaded_python();
+        let dir = tempdir().unwrap();
+        let mut memory =
+            PyTreeRingMemoryNative::open(dir.path().join(".tree-ring").display().to_string())
+                .unwrap();
+        let old_json = memory
+            .remember_event_json(
+                &serde_json::json!({
+                    "summary": "Old migration decision.",
+                    "event_type": "decision",
+                    "project": "migration"
+                })
+                .to_string(),
+            )
+            .unwrap();
+        let old: MemoryEvent = serde_json::from_str(&old_json).unwrap();
+        let new_json = memory
+            .remember_event_json(
+                &serde_json::json!({
+                    "summary": "New migration decision.",
+                    "event_type": "decision",
+                    "project": "migration",
+                    "supersedes": [old.id]
+                })
+                .to_string(),
+            )
+            .unwrap();
+        let new_event: MemoryEvent = serde_json::from_str(&new_json).unwrap();
+        let old_after = memory.store.get(&old.id).unwrap().unwrap();
+
+        assert_eq!(
+            old_after.superseded_by.as_deref(),
+            Some(new_event.id.as_str())
+        );
+        assert!(memory
+            .recall_query_json(
+                &serde_json::json!({
+                    "query": "migration decision",
+                    "project": "migration",
+                    "include_superseded": false
+                })
+                .to_string()
+            )
+            .unwrap()
+            .contains(&new_event.id));
+    }
+
+    #[test]
+    fn native_binding_recall_query_json_applies_filters_and_ranking() {
+        pyo3::prepare_freethreaded_python();
+        let dir = tempdir().unwrap();
+        let mut memory =
+            PyTreeRingMemoryNative::open(dir.path().join(".tree-ring").display().to_string())
+                .unwrap();
+        let target_json = memory
+            .remember_event_json(
+                &serde_json::json!({
+                    "summary": "Filtered native recall keeps durable Rust migration decisions.",
+                    "event_type": "decision",
+                    "scope": "project",
+                    "ring": "heartwood",
+                    "project": "migration",
+                    "agent_profile": "default",
+                    "tags": ["rust"]
+                })
+                .to_string(),
+            )
+            .unwrap();
+        let target: MemoryEvent = serde_json::from_str(&target_json).unwrap();
+        memory
+            .remember_event_json(
+                &serde_json::json!({
+                    "summary": "Filtered native recall should skip other projects.",
+                    "event_type": "lesson",
+                    "scope": "project",
+                    "ring": "outer",
+                    "project": "other",
+                    "agent_profile": "default",
+                    "tags": ["rust"]
+                })
+                .to_string(),
+            )
+            .unwrap();
+
+        let payload: serde_json::Value = serde_json::from_str(
+            &memory
+                .recall_query_json(
+                    &serde_json::json!({
+                        "query": "durable Rust migration decision",
+                        "project": "migration",
+                        "agent_profile": "default",
+                        "scope": "project",
+                        "rings": ["heartwood"],
+                        "event_types": ["decision"],
+                        "limit": 8,
+                        "explain_ranking": true
+                    })
+                    .to_string(),
+                )
+                .unwrap(),
+        )
+        .unwrap();
+
+        let results = payload.as_array().unwrap();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0]["memory"]["id"], target.id);
+        assert!(results[0]["ranking"]["source_authority"].is_number());
     }
 
     #[test]

--- a/docs/architecture/rust-core-status.md
+++ b/docs/architecture/rust-core-status.md
@@ -1,24 +1,31 @@
 # Rust Core Status
 
-Tree Ring Memory is moving from a Python reference package toward a Rust-first core with Python compatibility. This page tracks the v0.2 Rust core and v0.3 native Python binding work.
+Tree Ring Memory has moved from a Python-owned reference implementation toward
+a Rust-first core with Python compatibility. This page tracks the v0.2 Rust core
+and v0.3 native Python binding work.
 
 ## Current Status
 
-- Python remains the stable public reference implementation.
+- Python remains the stable public API surface.
 - Rust workspace exists under `crates/`.
 - Rust core owns model validation, sensitivity checks, and recall scoring.
 - Rust SQLite crate owns schema-compatible SQLite/FTS storage.
 - Rust CLI can initialize, remember, recall, and forget local memory.
 - Rust CLI has JSON output for machine-readable adapter use.
 - Python has an explicit `RustCliTreeRingMemory` compatibility adapter.
-- Python also has an explicit `NativeTreeRingMemory` preview wrapper backed by
-  the optional PyO3 module in `bindings/python`.
+- Python has an explicit `NativeTreeRingMemory` wrapper backed by the optional
+  PyO3 module in `bindings/python`.
+- The public `TreeRingMemory.open()` facade is Rust-first when the native module
+  is installed. It falls back to the explicit `PythonTreeRingMemory` reference
+  backend in source checkouts unless native is required by configuration.
 - The v0.2 adapter is intentionally limited: `remember` supports summary,
   event type, ring, scope, project, and tags; `recall` supports query, project,
   limit, and sensitive-memory inclusion. Unsupported Python facade fields raise
   `NotImplementedError`.
-- The default `TreeRingMemory` facade remains Python-backed until native parity
-  is broader.
+- The v0.3 native backend supports the full public `remember()` and `recall()`
+  contracts, including details, source metadata, agent profile, scores,
+  retention, expiry, links, review metadata, supersession, recall filters,
+  superseded-memory inclusion, and ranking explanations.
 
 ## Build Commands
 
@@ -46,12 +53,12 @@ database/schema compatibility and Python return-object compatibility for the
 supported v0.2 subset while keeping the stable Python reference implementation
 unchanged.
 
-## Python Native Binding Preview
+## Python Native Backend
 
 ```python
-from tree_ring_memory import NativeTreeRingMemory
+from tree_ring_memory import TreeRingMemory
 
-memory = NativeTreeRingMemory.open(".tree-ring")
+memory = TreeRingMemory.open(".tree-ring")
 event = memory.remember(summary="Native Rust path works.", event_type="lesson")
 results = memory.recall("Rust path")
 ```
@@ -62,15 +69,24 @@ binding package is extension-only and does not package or own the public
 `tree_ring_memory` Python package. If the module is absent, the wrapper raises a
 clear `ImportError` with that build hint.
 
+Backend controls:
+
+- `TREE_RING_MEMORY_BACKEND=auto`: use Rust native when available, otherwise
+  Python reference fallback.
+- `TREE_RING_MEMORY_BACKEND=native` or `TREE_RING_MEMORY_REQUIRE_NATIVE=1`:
+  require Rust native bindings.
+- `TREE_RING_MEMORY_BACKEND=python`: force the reference backend.
+
 ## Smoke Coverage
 
 - Rust unit tests cover model validation, sensitivity checks, recall scoring,
   SQLite/FTS storage, transactional row/FTS consistency, redaction, and basic
   concurrent writes. Rust binding tests cover native JSON remember/recall
   round-trip and forget validation.
-- Python tests cover the existing reference package, Rust CLI database
-  compatibility, the opt-in `RustCliTreeRingMemory` adapter, and the clean
-  missing-extension path for `NativeTreeRingMemory`.
+- Python tests cover the existing reference backend, Rust CLI database
+  compatibility, the opt-in `RustCliTreeRingMemory` adapter, default facade
+  native selection, full native wrapper argument marshalling, and clean
+  missing-extension behavior.
 - `scripts/rust_performance_smoke.py` provides an operator-run local insert and
   recall timing check. It fails if expected recalls are empty, emits a stable
   `METRICS_JSON=` line, and enforces conservative synthetic-workload thresholds
@@ -78,11 +94,13 @@ clear `ImportError` with that build hint.
 
 Latest local smoke on July 5, 2026 with `--count 10000`:
 
-- Inserted 10,000 memories in 4,595.5 ms.
-- Insert throughput: 2,176.0 inserts/sec.
-- Recall average latency: 8.706 ms.
-- Recall max latency: 17.211 ms.
+- Inserted 10,000 memories in 4,598.8 ms.
+- Insert throughput: 2,174.5 inserts/sec.
+- Recall average latency: 8.142 ms.
+- Recall max latency: 15.017 ms.
 
 ## Compatibility Rule
 
-Rust must read and write the same SQLite shape and JSON memory event payloads as the Python reference until an explicit migration exists.
+Rust must read and write the same SQLite shape and JSON memory event payloads as
+the Python reference. Python reference code is compatibility scaffolding, not
+the target behavioral owner.

--- a/scripts/native_binding_smoke.py
+++ b/scripts/native_binding_smoke.py
@@ -49,10 +49,17 @@ def main() -> int:
                 str(python),
                 "-c",
                 (
+                    "import tempfile; "
+                    "from pathlib import Path; "
                     "from tree_ring_memory import TreeRingMemory, NativeTreeRingMemory; "
                     "import tree_ring_memory._tree_ring_memory_native as native; "
                     "assert TreeRingMemory.__module__ == 'tree_ring_memory.api'; "
                     "assert NativeTreeRingMemory.__module__ == 'tree_ring_memory.native_backend'; "
+                    "memory = TreeRingMemory.open(Path(tempfile.mkdtemp()) / '.tree-ring'); "
+                    "assert memory.backend_name == 'rust-native'; "
+                    "event = memory.remember(summary='Native default facade works.', event_type='lesson'); "
+                    "results = memory.recall('native facade'); "
+                    "assert results and results[0].memory.id == event.id; "
                     "print(native.native_version())"
                 ),
             ]

--- a/src/tree_ring_memory/__init__.py
+++ b/src/tree_ring_memory/__init__.py
@@ -4,7 +4,7 @@ from pkgutil import extend_path
 
 __path__ = extend_path(__path__, __name__)
 
-from tree_ring_memory.api import TreeRingMemory
+from tree_ring_memory.api import PythonTreeRingMemory, TreeRingMemory
 from tree_ring_memory.models import MemoryEvent, MemoryLink, MemoryReview, MemorySource, ValidationError
 from tree_ring_memory.native_backend import NativeTreeRingMemory
 from tree_ring_memory.rust_backend import RustCliTreeRingMemory
@@ -12,6 +12,7 @@ from tree_ring_memory.rust_backend import RustCliTreeRingMemory
 
 __all__ = [
     "NativeTreeRingMemory",
+    "PythonTreeRingMemory",
     "TreeRingMemory",
     "RustCliTreeRingMemory",
     "MemoryEvent",

--- a/src/tree_ring_memory/api.py
+++ b/src/tree_ring_memory/api.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 from pathlib import Path
 from typing import Sequence
 
@@ -9,7 +10,9 @@ from tree_ring_memory.sensitivity import SensitivityGuard, SensitivityResult
 from tree_ring_memory.store import SQLiteMemoryStore
 
 
-class TreeRingMemory:
+class PythonTreeRingMemory:
+    backend_name = "python-reference"
+
     def __init__(self, root: Path, store: SQLiteMemoryStore) -> None:
         self.root = root
         self.store = store
@@ -17,7 +20,7 @@ class TreeRingMemory:
         self._sensitivity_guard = SensitivityGuard()
 
     @classmethod
-    def open(cls, root: str | Path) -> TreeRingMemory:
+    def open(cls, root: str | Path) -> PythonTreeRingMemory:
         root = Path(root)
         root.mkdir(parents=True, exist_ok=True)
         return cls(root, SQLiteMemoryStore.open(root / "memory.sqlite"))
@@ -154,6 +157,35 @@ class TreeRingMemory:
 
     def _check_public_text_fields(self, *values: str | None) -> list[SensitivityResult]:
         return [self._sensitivity_guard.check_or_raise(value or "") for value in values]
+
+
+class TreeRingMemory:
+    """Rust-first public facade.
+
+    Python remains available as a source-checkout fallback when the optional
+    native extension is not installed. Set `TREE_RING_MEMORY_BACKEND=python` to
+    force the reference path, or `TREE_RING_MEMORY_REQUIRE_NATIVE=1` to fail
+    instead of falling back.
+    """
+
+    @classmethod
+    def open(cls, root: str | Path):
+        backend = os.environ.get("TREE_RING_MEMORY_BACKEND", "auto").casefold()
+        if backend == "python":
+            return PythonTreeRingMemory.open(root)
+        if backend not in {"auto", "native", "rust", "rust-native"}:
+            raise ValueError(f"unsupported Tree Ring Memory backend: {backend}")
+
+        try:
+            from tree_ring_memory.native_backend import NativeBindingNotInstalled, NativeTreeRingMemory
+
+            return NativeTreeRingMemory.open(root)
+        except NativeBindingNotInstalled:
+            if backend in {"native", "rust", "rust-native"} or os.environ.get(
+                "TREE_RING_MEMORY_REQUIRE_NATIVE"
+            ) == "1":
+                raise
+            return PythonTreeRingMemory.open(root)
 
 
 def _detected_sensitivity(*results: SensitivityResult) -> str:

--- a/src/tree_ring_memory/native_backend.py
+++ b/src/tree_ring_memory/native_backend.py
@@ -4,34 +4,43 @@ import importlib
 import json
 from pathlib import Path
 from typing import Any
+from datetime import datetime
 
-from tree_ring_memory.models import MemoryEvent
+from tree_ring_memory.models import MemoryEvent, MemoryLink, MemoryReview, MemorySource
 from tree_ring_memory.recall import RecallResult
+
+
+class NativeBindingNotInstalled(ImportError):
+    """Raised when the optional Rust native module is absent."""
 
 
 class NativeTreeRingMemory:
     """Python facade for the optional PyO3 native module.
 
-    This v0.3 preview wrapper is intentionally explicit. The default
-    `TreeRingMemory` facade remains Python-backed until native parity is broader.
+    The public `TreeRingMemory` facade uses this Rust-native backend by default
+    when the extension is installed.
     """
 
-    def __init__(self, native: Any) -> None:
+    backend_name = "rust-native"
+
+    def __init__(self, native: Any, root: Path) -> None:
         self._native = native
+        self.root = root
 
     @classmethod
     def open(cls, root: str | Path) -> NativeTreeRingMemory:
+        root = Path(root)
         module_name = "tree_ring_memory._tree_ring_memory_native"
         try:
             native_module = importlib.import_module(module_name)
         except ModuleNotFoundError as exc:
             if exc.name != module_name:
                 raise
-            raise ImportError(
+            raise NativeBindingNotInstalled(
                 "Tree Ring Memory native bindings are not installed. "
                 "Build them with `cd bindings/python && maturin develop`."
             ) from exc
-        return cls(native_module.TreeRingMemoryNative.open(str(root)))
+        return cls(native_module.TreeRingMemoryNative.open(str(root)), root)
 
     def remember(
         self,
@@ -41,9 +50,39 @@ class NativeTreeRingMemory:
         scope: str = "global",
         ring: str = "cambium",
         project: str | None = None,
+        agent_profile: str | None = None,
+        details: str = "",
+        source: MemorySource | None = None,
         tags: list[str] | None = None,
+        salience: float = 0.5,
+        confidence: float = 0.5,
+        sensitivity: str = "normal",
+        retention: str = "normal",
+        expires_at=None,
+        supersedes: list[str] | None = None,
+        links: list[MemoryLink] | None = None,
+        review: MemoryReview | None = None,
     ) -> MemoryEvent:
-        payload = self._native.remember_json(summary, event_type, ring, scope, project, tags or [])
+        request = {
+            "summary": summary,
+            "event_type": event_type,
+            "scope": scope,
+            "ring": ring,
+            "project": project,
+            "agent_profile": agent_profile,
+            "details": details,
+            "source": (source or MemorySource()).to_dict(),
+            "tags": tags or [],
+            "salience": salience,
+            "confidence": confidence,
+            "sensitivity": sensitivity,
+            "retention": retention,
+            "expires_at": _iso_or_none(expires_at),
+            "supersedes": supersedes or [],
+            "links": [link.to_dict() for link in links or []],
+            "review": (review or MemoryReview()).to_dict(),
+        }
+        payload = self._native.remember_event_json(json.dumps(request, sort_keys=True))
         return MemoryEvent.from_dict(json.loads(payload))
 
     def recall(
@@ -51,10 +90,28 @@ class NativeTreeRingMemory:
         query: str,
         *,
         project: str | None = None,
+        agent_profile: str | None = None,
+        scope: str | None = None,
+        rings: list[str] | None = None,
+        event_types: list[str] | None = None,
         include_sensitive: bool = False,
+        include_superseded: bool = False,
         limit: int = 8,
+        explain_ranking: bool = False,
     ) -> list[RecallResult]:
-        payload = json.loads(self._native.recall_json(query, project, limit, include_sensitive))
+        request = {
+            "query": query,
+            "project": project,
+            "agent_profile": agent_profile,
+            "scope": scope,
+            "rings": rings,
+            "event_types": event_types,
+            "include_sensitive": include_sensitive,
+            "include_superseded": include_superseded,
+            "limit": limit,
+            "explain_ranking": explain_ranking,
+        }
+        payload = json.loads(self._native.recall_query_json(json.dumps(request, sort_keys=True)))
         return [
             RecallResult(
                 memory=MemoryEvent.from_dict(item["memory"]),
@@ -66,3 +123,11 @@ class NativeTreeRingMemory:
 
     def forget(self, memory_id: str, *, mode: str, reason: str) -> None:
         self._native.forget(memory_id, mode, reason)
+
+
+def _iso_or_none(value: Any) -> str | None:
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        return value.isoformat()
+    return str(value)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,6 +2,7 @@ import json
 import os
 import subprocess
 import sys
+import types
 from pathlib import Path
 
 import pytest
@@ -9,7 +10,7 @@ import pytest
 from tree_ring_memory import TreeRingMemory
 import tree_ring_memory.native_backend as native_backend
 from tree_ring_memory.native_backend import NativeTreeRingMemory
-from tree_ring_memory.models import MemorySource
+from tree_ring_memory.models import MemoryLink, MemoryReview, MemorySource
 from tree_ring_memory.store import SQLiteMemoryStore
 from tree_ring_memory.rust_backend import RustCliTreeRingMemory
 
@@ -233,6 +234,136 @@ def test_native_backend_preserves_broken_extension_import_error(tmp_path, monkey
 
     with pytest.raises(ImportError, match="dlopen failed"):
         NativeTreeRingMemory.open(tmp_path / ".tree-ring")
+
+
+def test_default_facade_does_not_fallback_when_native_extension_is_broken(tmp_path, monkeypatch):
+    def broken_import(name):
+        assert name == "tree_ring_memory._tree_ring_memory_native"
+        raise ImportError("dlopen failed")
+
+    monkeypatch.setattr(native_backend.importlib, "import_module", broken_import)
+
+    with pytest.raises(ImportError, match="dlopen failed"):
+        TreeRingMemory.open(tmp_path / ".tree-ring")
+
+
+def test_default_facade_uses_native_backend_when_extension_is_available(tmp_path, monkeypatch):
+    class FakeNativeStore:
+        @staticmethod
+        def open(root):
+            return {"root": root}
+
+    fake_module = types.SimpleNamespace(TreeRingMemoryNative=FakeNativeStore)
+    monkeypatch.setattr(
+        native_backend.importlib,
+        "import_module",
+        lambda name: fake_module if name == "tree_ring_memory._tree_ring_memory_native" else None,
+    )
+
+    memory = TreeRingMemory.open(tmp_path / ".tree-ring")
+
+    assert isinstance(memory, NativeTreeRingMemory)
+    assert memory.backend_name == "rust-native"
+
+
+def test_native_backend_remember_sends_full_facade_contract(tmp_path):
+    class FakeNativeStore:
+        def __init__(self):
+            self.request = None
+
+        def remember_event_json(self, request_json):
+            self.request = json.loads(request_json)
+            return json.dumps(
+                {
+                    "id": "mem_native",
+                    "created_at": "2026-07-05T00:00:00+00:00",
+                    "updated_at": "2026-07-05T00:00:00+00:00",
+                    "project": self.request["project"],
+                    "agent_profile": self.request["agent_profile"],
+                    "scope": self.request["scope"],
+                    "ring": self.request["ring"],
+                    "event_type": self.request["event_type"],
+                    "summary": self.request["summary"],
+                    "details": self.request["details"],
+                    "source": self.request["source"],
+                    "tags": self.request["tags"],
+                    "salience": self.request["salience"],
+                    "confidence": self.request["confidence"],
+                    "sensitivity": self.request["sensitivity"],
+                    "retention": self.request["retention"],
+                    "expires_at": self.request["expires_at"],
+                    "supersedes": self.request["supersedes"],
+                    "superseded_by": None,
+                    "links": self.request["links"],
+                    "review": self.request["review"],
+                }
+            )
+
+    fake_native = FakeNativeStore()
+    memory = NativeTreeRingMemory(fake_native, tmp_path / ".tree-ring")
+
+    event = memory.remember(
+        summary="Rust owns wrapper contract.",
+        details="Full detail",
+        event_type="decision",
+        scope="project",
+        ring="heartwood",
+        project="migration",
+        agent_profile="default",
+        source=MemorySource(type="file", ref="README.md"),
+        tags=["rust"],
+        salience=0.7,
+        confidence=0.8,
+        sensitivity="private",
+        retention="durable",
+        supersedes=["mem_old"],
+        links=[MemoryLink(type="file", target="README.md")],
+        review=MemoryReview(needs_review=True, review_reason="parity"),
+    )
+
+    assert event.id == "mem_native"
+    assert fake_native.request["details"] == "Full detail"
+    assert fake_native.request["source"]["ref"] == "README.md"
+    assert fake_native.request["links"] == [{"type": "file", "target": "README.md"}]
+    assert fake_native.request["review"]["needs_review"] is True
+
+
+def test_native_backend_recall_sends_full_filter_contract(tmp_path):
+    class FakeNativeStore:
+        def __init__(self):
+            self.request = None
+
+        def recall_query_json(self, request_json):
+            self.request = json.loads(request_json)
+            return "[]"
+
+    fake_native = FakeNativeStore()
+    memory = NativeTreeRingMemory(fake_native, tmp_path / ".tree-ring")
+
+    assert memory.recall(
+        "migration",
+        project="tree-ring",
+        agent_profile="default",
+        scope="project",
+        rings=["heartwood"],
+        event_types=["decision"],
+        include_sensitive=True,
+        include_superseded=True,
+        limit=3,
+        explain_ranking=True,
+    ) == []
+    assert fake_native.request == {
+        "query": "migration",
+        "project": "tree-ring",
+        "agent_profile": "default",
+        "scope": "project",
+        "rings": ["heartwood"],
+        "event_types": ["decision"],
+        "include_sensitive": True,
+        "include_superseded": True,
+        "limit": 3,
+        "explain_ranking": True,
+    }
 
 
 def test_rust_cli_backend_prefers_configured_binary(tmp_path, monkeypatch):

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -129,11 +129,11 @@ def test_search_text_does_not_treat_or_as_boolean_operator(tmp_path):
     assert store.search_text("cache OR SQLite") == []
 
 
-from tree_ring_memory import TreeRingMemory
+from tree_ring_memory import PythonTreeRingMemory
 
 
 def test_facade_remember_recall_and_forget(tmp_path):
-    memory = TreeRingMemory.open(tmp_path / ".tree-ring")
+    memory = PythonTreeRingMemory.open(tmp_path / ".tree-ring")
     event = memory.remember(summary="Facade stores memory.", event_type="lesson", tags=["facade"])
 
     results = memory.recall("facade")
@@ -144,7 +144,7 @@ def test_facade_remember_recall_and_forget(tmp_path):
 
 
 def test_facade_blocks_secret_by_default(tmp_path):
-    memory = TreeRingMemory.open(tmp_path / ".tree-ring")
+    memory = PythonTreeRingMemory.open(tmp_path / ".tree-ring")
 
     try:
         memory.remember(summary="token = sk-proj-abcdefghijklmnopqrstuvwxyz1234567890", event_type="lesson")
@@ -155,7 +155,7 @@ def test_facade_blocks_secret_by_default(tmp_path):
 
 
 def test_facade_blocks_secret_tag_by_default(tmp_path):
-    memory = TreeRingMemory.open(tmp_path / ".tree-ring")
+    memory = PythonTreeRingMemory.open(tmp_path / ".tree-ring")
 
     with pytest.raises(ValueError, match="blocked"):
         memory.remember(
@@ -166,7 +166,7 @@ def test_facade_blocks_secret_tag_by_default(tmp_path):
 
 
 def test_facade_blocks_secret_source_ref_by_default(tmp_path):
-    memory = TreeRingMemory.open(tmp_path / ".tree-ring")
+    memory = PythonTreeRingMemory.open(tmp_path / ".tree-ring")
 
     with pytest.raises(ValueError, match="blocked"):
         memory.remember(
@@ -177,7 +177,7 @@ def test_facade_blocks_secret_source_ref_by_default(tmp_path):
 
 
 def test_facade_blocks_secret_link_target_by_default(tmp_path):
-    memory = TreeRingMemory.open(tmp_path / ".tree-ring")
+    memory = PythonTreeRingMemory.open(tmp_path / ".tree-ring")
 
     with pytest.raises(ValueError, match="blocked"):
         memory.remember(
@@ -188,7 +188,7 @@ def test_facade_blocks_secret_link_target_by_default(tmp_path):
 
 
 def test_facade_blocks_secret_supersedes_by_default(tmp_path):
-    memory = TreeRingMemory.open(tmp_path / ".tree-ring")
+    memory = PythonTreeRingMemory.open(tmp_path / ".tree-ring")
 
     with pytest.raises(ValueError, match="blocked"):
         memory.remember(
@@ -207,7 +207,7 @@ def test_facade_blocks_secret_supersedes_by_default(tmp_path):
     ],
 )
 def test_facade_blocks_secret_review_fields_by_default(tmp_path, review):
-    memory = TreeRingMemory.open(tmp_path / ".tree-ring")
+    memory = PythonTreeRingMemory.open(tmp_path / ".tree-ring")
 
     with pytest.raises(ValueError, match="blocked"):
         memory.remember(
@@ -218,7 +218,7 @@ def test_facade_blocks_secret_review_fields_by_default(tmp_path, review):
 
 
 def test_facade_supersedes_hides_old_memory_by_default(tmp_path):
-    memory = TreeRingMemory.open(tmp_path / ".tree-ring")
+    memory = PythonTreeRingMemory.open(tmp_path / ".tree-ring")
     old = memory.remember(summary="Use polling invalidation.", event_type="decision")
     new = memory.remember(
         summary="Use snapshot invalidation.",
@@ -232,7 +232,7 @@ def test_facade_supersedes_hides_old_memory_by_default(tmp_path):
 
 
 def test_facade_redact_clears_secret_source_ref_from_storage_and_recall(tmp_path):
-    memory = TreeRingMemory.open(tmp_path / ".tree-ring")
+    memory = PythonTreeRingMemory.open(tmp_path / ".tree-ring")
     secret_ref = "sk-proj-abcdefghijklmnopqrstuvwxyz1234567890"
     event = MemoryEvent.new(
         summary="Legacy memory with source ref.",
@@ -260,7 +260,7 @@ def test_facade_redact_clears_secret_source_ref_from_storage_and_recall(tmp_path
 
 
 def test_facade_redact_clears_secret_metadata_from_storage_and_recall(tmp_path):
-    memory = TreeRingMemory.open(tmp_path / ".tree-ring")
+    memory = PythonTreeRingMemory.open(tmp_path / ".tree-ring")
     secret = "sk-proj-abcdefghijklmnopqrstuvwxyz1234567890"
     event = MemoryEvent.new(
         summary="Legacy memory with secret metadata.",
@@ -303,7 +303,7 @@ def test_facade_redact_clears_secret_metadata_from_storage_and_recall(tmp_path):
 
 
 def test_facade_redact_clears_secret_superseded_by_from_storage(tmp_path):
-    memory = TreeRingMemory.open(tmp_path / ".tree-ring")
+    memory = PythonTreeRingMemory.open(tmp_path / ".tree-ring")
     secret = "sk-proj-abcdefghijklmnopqrstuvwxyz1234567890"
     old = MemoryEvent.new(summary="Legacy superseded memory.", event_type="lesson")
     memory.store.put(old)


### PR DESCRIPTION
Summary:
- Make TreeRingMemory.open() use the Rust-native PyO3 backend by default when installed, with explicit native/python backend controls.
- Expand the native backend to cover the full public remember/recall contracts, including source metadata, details, agent profile, scores, retention, expiry, links, review metadata, supersession, filters, superseded inclusion, and ranking explanations.
- Keep Python as a compatibility/reference fallback only, update docs and native smoke, and prevent broken installed native extensions from silently falling back to Python.

Verification:
- cargo test: passed.
- python3 -m pytest: 80 passed.
- python3 -m pytest tests/test_cli.py tests/test_store.py tests/test_native_packaging.py: 46 passed.
- cargo test -p tree-ring-memory-python: passed, 8 tests.
- cargo build -p tree-ring-memory-python --features extension-module: passed.
- python3 scripts/native_binding_smoke.py --install-maturin: passed; default TreeRingMemory facade resolved to rust-native and native_version reported 0.3.0.
- python3 scripts/rust_performance_smoke.py --count 10000: passed; 10,000 inserts, 2,174.5 inserts/sec, recall avg 8.142 ms, max 15.017 ms.

Notes:
- PR #4 merged before this final Rust-first commit, so this follow-up carries the remaining migration phase.
- .vscode/ remains untracked and was not included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added backend selection for the memory API, letting users choose native Rust or Python reference behavior via environment settings.
  * Expanded the public memory interface with richer remember/recall support, including more metadata, filters, and ranking details.
* **Bug Fixes**
  * Unsupported fields now fail clearly instead of being silently ignored.
  * Native backend fallback behavior is more explicit when the extension is unavailable.
* **Documentation**
  * Updated status and architecture docs to reflect the current Rust-first behavior and backend selection options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->