### PR TITLE
Design Ratatui tree ring operator console

### DIFF
--- a/docs/feature/tree-ring-memory-tui/diverge/options-raw.md
+++ b/docs/feature/tree-ring-memory-tui/diverge/options-raw.md
@@ -1,0 +1,112 @@
+# Tree Ring Memory TUI Options
+
+## HMW Question
+
+How might we give humans and AI agents a fast, emotionally clear terminal view of memory health, ring composition, and lifecycle actions without turning Tree Ring Memory into a transcript browser?
+
+## SCAMPER Options
+
+### Option 1: Ring-First Observatory
+
+**Core idea**: The user opens `tree-ring tui` and sees a live animated ASCII tree-ring core with secondary panes for search and details.
+**Key mechanism**: Ratatui renders the ring visualization as the dominant state instrument, fed by store-watch and event-stream updates.
+**Key assumption**: Users need fast confidence in memory health before they need dense editing workflows.
+**SCAMPER origin**: Substitute.
+**Closest competitor**: Terminal dashboards like `btop`, but memory-lifecycle specific.
+
+### Option 2: Operator Console
+
+**Core idea**: The user works primarily through search, details, and action panels while the ring visualization sits as a persistent status sidebar.
+**Key mechanism**: Ratatui tables, detail panes, command palette, and confirmation modals carry most of the experience.
+**Key assumption**: Most users enter the TUI to act on memories, not admire memory state.
+**SCAMPER origin**: Combine.
+**Closest competitor**: Database/browser TUIs that pair a list, details, and command actions.
+
+### Option 3: Retro Ring Console
+
+**Core idea**: The TUI borrows from retro roller-rink signage: saturated ring colors, pulsing ASCII arcs, and glowing memory states.
+**Key mechanism**: Color and pulse intensity encode memory category, count, recency, and severity.
+**Key assumption**: Emotional affordance improves operator understanding without sacrificing terminal efficiency.
+**SCAMPER origin**: Adapt.
+**Closest competitor**: Stylized TUIs like Lazygit themes, but driven by semantic memory state.
+
+### Option 4: Exploded Ring Inspector
+
+**Core idea**: A slash command breaks the live core into separated rings with floating data bubbles for counts, sensitivity, scars, seeds, and freshness.
+**Key mechanism**: The app has a dedicated expanded visualization mode with animated offsets and focused ring panels.
+**Key assumption**: Users sometimes need a memorable, inspectable cross-section more than a compact dashboard.
+**SCAMPER origin**: Modify/Magnify.
+**Closest competitor**: System topology views, adapted to temporal memory rings.
+
+### Option 5: Agent Harness Overlay
+
+**Core idea**: Agent frameworks can stream live memory lifecycle events into the TUI so the ring pulses as agents remember, recall, redact, or consolidate.
+**Key mechanism**: A local framework-agnostic event stream is merged with persisted SQLite state.
+**Key assumption**: AI-agent operators benefit from seeing memory behavior while work is happening, before every event has settled into storage.
+**SCAMPER origin**: Put to other use.
+**Closest competitor**: Live log/event consoles, but interpreted through memory lifecycle state.
+
+### Option 6: Minimal Safe Actions
+
+**Core idea**: Remove most write actions from v1 and keep only read/search plus redaction/forget.
+**Key mechanism**: Lower action surface reduces safety risk.
+**Key assumption**: Users prefer correctness over complete terminal operation.
+**SCAMPER origin**: Eliminate.
+**Closest competitor**: Read-mostly admin dashboards.
+
+### Option 7: Memory Interview Mode
+
+**Core idea**: The TUI asks the user what they want to do, then builds a guided memory operation backwards from intent.
+**Key mechanism**: Command flow starts with desired outcome and only then picks recall, remember, redact, promote, or forget.
+**Key assumption**: Users know the job they want done better than they know memory lifecycle commands.
+**SCAMPER origin**: Reverse.
+**Closest competitor**: Wizard-style terminal apps.
+
+## Crazy 8s Supplements
+
+### Option 8: Timeline Strip
+
+**Core idea**: A horizontal time strip shows recent cambium and older rings as compressing segments.
+**Key mechanism**: The ring visual is paired with a temporal sparkline.
+**Key assumption**: Memory aging needs a time metaphor as well as a ring metaphor.
+**SCAMPER origin**: Crazy 8s supplement.
+**Closest competitor**: Git history timelines.
+
+### Option 9: Memory Health HUD
+
+**Core idea**: A compact heads-up display scores memory health: fresh, stable, scar-heavy, seed-heavy, sensitive, stale, or contradictory.
+**Key mechanism**: Aggregated metrics become a concise live label above the ring core.
+**Key assumption**: Users need one glanceable health summary before deeper drilldown.
+**SCAMPER origin**: Crazy 8s supplement.
+**Closest competitor**: CI status dashboards.
+
+### Option 10: Agent Pairing Console
+
+**Core idea**: The TUI exposes one pane for human actions and one pane for agent event-stream activity.
+**Key mechanism**: Store-watch and event-stream inputs are visually separated but reconciled into one ring state.
+**Key assumption**: Human and agent memory actions need separate accountability in the same terminal.
+**SCAMPER origin**: Crazy 8s supplement.
+**Closest competitor**: Pair-programming terminal dashboards.
+
+## Curated 6
+
+1. **Ring-First Observatory**: Different mechanism, behavior assumption, and cost profile from the action-heavy options.
+2. **Operator Console**: Dense action workflow and lower visual emphasis.
+3. **Exploded Ring Inspector**: Dedicated visual inspection mode.
+4. **Agent Harness Overlay**: Event-stream integration for framework-agnostic live updates.
+5. **Memory Health HUD**: Glanceable state summary.
+6. **Memory Interview Mode**: Guided action model for safer writes.
+
+## Selected Direction
+
+The selected direction is a **Dual-Mode Ring Console**:
+
+- Default view combines Ring-First Observatory, Operator Console, Agent Harness Overlay, and Memory Health HUD.
+- `/rings` opens the Exploded Ring Inspector.
+- Write actions use a constrained version of Memory Interview Mode through guided confirmations.
+
+## Eliminated Or Merged Options
+
+- **Retro Ring Console** is not standalone; it becomes the visual language for all selected modes.
+- **Minimal Safe Actions** conflicts with the user's selected full operator console, but its safety concern remains as confirmations for destructive, sensitive, or authority-changing actions.
+- **Timeline Strip** is deferred to a later view after the ring dashboard, exploded rings, search, and actions are solid.

--- a/docs/superpowers/specs/2026-07-05-tree-ring-memory-ratatui-tui-design.md
+++ b/docs/superpowers/specs/2026-07-05-tree-ring-memory-ratatui-tui-design.md
@@ -1,0 +1,252 @@
+# Tree Ring Memory Ratatui TUI Design
+
+## Summary
+
+Tree Ring Memory needs a Rust-native terminal interface for humans and AI-agent operators. The interface should preserve the project purpose: a framework-agnostic memory lifecycle layer for agents, not a transcript browser. It should make useful memory visible by age, type, sensitivity, confidence, scars, seeds, and durable heartwood.
+
+The selected design is a **Dual-Mode Ring Console** built with Ratatui in the Rust workspace. The default screen balances a live ambient ASCII tree-ring core with search, details, and safe action panels. A slash-command palette can expand the core into an animated exploded-ring view where each ring separates from the center and shows data bubbles.
+
+## Product Constraints
+
+- The TUI must be Rust-first. It belongs in the Rust CLI/workspace, not in Python.
+- Python remains wrapper and compatibility surface only.
+- The TUI must use local SQLite/FTS storage and Rust lifecycle APIs.
+- The TUI must remain framework-agnostic. Agent harnesses can integrate through an event stream, but no harness is privileged.
+- The TUI must not become a transcript browser or raw log viewer.
+- DOX and Revolve remain inspirations and integration points, not systems replaced by the TUI.
+
+## Launch Model
+
+Primary launch:
+
+```bash
+tree-ring tui
+```
+
+The existing scriptable CLI commands remain available:
+
+```bash
+tree-ring remember ...
+tree-ring recall ...
+tree-ring forget ...
+```
+
+No-subcommand launch should remain conservative for now. The TUI is substantial enough that it should be explicit.
+
+## Visual Language
+
+The persistent visual anchor is an animated ASCII tree-ring core inspired by the retro ring logo. It should use terminal-safe retro colors:
+
+- Cambium: bright amber/orange for fresh active work.
+- Outer ring: warm coral/pink for recent structured memory.
+- Inner ring: teal for compressed older memory.
+- Heartwood: golden/yellow for durable truth.
+- Scars: red/pink warning accents.
+- Seeds: cyan/green-blue for future work and hypotheses.
+- Sensitive/private state: dimmed violet or guarded outline, never flashy.
+
+The ambient core should pulse slightly even when idle. Real-time changes brighten the affected ring briefly and then decay back to the baseline. The pulse is meaningful:
+
+- New memory: target ring brightens.
+- Recall hit: matching rings shimmer.
+- Scar relevance: scar mark flashes with warning color.
+- Heartwood promotion: center warms and stabilizes.
+- Seed backlog growth: seed ring pulses cyan.
+- Sensitive memory detected: guarded outline appears and decays slowly.
+
+Animation must degrade cleanly in terminals without truecolor or sufficient size.
+
+## Modes
+
+### Default Console
+
+The default mode includes:
+
+- Left or top-left: ambient live ASCII tree-ring core.
+- Status HUD: total memories, health label, last refresh, event-stream state.
+- Search/results pane.
+- Selected memory detail pane.
+- Action rail with available operations.
+
+The layout should use Ratatui layout primitives and stay readable in 100x30 terminals. Smaller terminals fall back to stacked panes.
+
+### Exploded Rings
+
+`/rings` opens the expanded visual mode. Rings separate from the core with animated offsets. Each ring has a data bubble:
+
+- Ring name.
+- Count.
+- Top event types.
+- Average confidence and salience.
+- Oldest/newest timestamps.
+- Sensitive/private count.
+- Scar/seed/heartwood-specific notes.
+
+This mode is visual-first but still keyboard-operable. Enter selects a ring; Escape returns to default.
+
+### Search And Detail
+
+`/search` focuses recall. Search results should support:
+
+- Query input.
+- Ring filters.
+- Event type filters.
+- Project and agent-profile filters.
+- Include sensitive toggle.
+- Include superseded toggle.
+- Ranking explanation toggle.
+
+Selected memory detail shows summary, details, source, links, tags, sensitivity, salience, confidence, supersession chain, and review flags.
+
+### Action Flows
+
+The TUI is a full operator console. It supports:
+
+- `/remember`
+- `/forget`
+- `/redact`
+- `/promote`
+- `/scar`
+- `/seed`
+- `/supersede`
+- `/consolidate`
+- `/export`
+- `/sync`
+
+Hybrid interaction model:
+
+- Navigation and focus are keyboard-first.
+- Destructive, sensitive, or authority-changing actions use guided confirmation.
+- Confirmation panels summarize exactly what will change.
+- Secret-like input fails closed and shows a policy-safe error.
+
+## Real-Time Inputs
+
+The TUI combines two live sources.
+
+### Store-Watch Real-Time
+
+The app watches or polls the SQLite store for persisted memory changes. v1 may use low-latency polling if cross-platform file watching is noisy. The design should isolate this behind a `StoreWatcher` abstraction so native file notification can replace polling later.
+
+Store-watch updates drive authoritative counts and search refreshes.
+
+### Event-Stream Real-Time
+
+The app exposes a framework-agnostic local event stream for AI-agent harnesses and companion tools. The stream is optional. Events are treated as live signals until persisted storage confirms them.
+
+Initial event types:
+
+- `remember_started`
+- `remembered`
+- `recall_started`
+- `recalled`
+- `forgotten`
+- `redacted`
+- `promoted`
+- `marked_scar`
+- `marked_seed`
+- `consolidated`
+- `sync_started`
+- `sync_finished`
+- `policy_blocked`
+
+Each event should include timestamp, optional project, optional agent profile, ring, event type, count delta, and a policy-safe label. Event payloads must not require secrets or raw transcripts.
+
+## Architecture
+
+Recommended Rust structure:
+
+```text
+crates/tree-ring-memory-cli/src/
+├── main.rs
+├── tui/
+│   ├── app.rs
+│   ├── event.rs
+│   ├── input.rs
+│   ├── model.rs
+│   ├── render.rs
+│   ├── rings.rs
+│   ├── actions.rs
+│   ├── store_watch.rs
+│   └── stream.rs
+```
+
+Responsibilities:
+
+- `app.rs`: app state and mode transitions.
+- `event.rs`: terminal ticks, key events, store updates, stream events.
+- `input.rs`: slash-command palette and key handling.
+- `model.rs`: derived dashboard state from store and events.
+- `render.rs`: top-level Ratatui rendering.
+- `rings.rs`: ASCII ring geometry, color mapping, pulse decay.
+- `actions.rs`: remember/forget/redact/promote/scar/seed/consolidate flows.
+- `store_watch.rs`: SQLite refresh and store-change detection.
+- `stream.rs`: optional local event stream.
+
+Ratatui should use its default crossterm backend first. Ratatui documentation currently shows `ratatui = "0.30.2"` and default crossterm support, with documented support for widgets, layouts, styling, popups, tables, charts, gauges, and event handling.
+
+## State Model
+
+The TUI should derive a compact state snapshot:
+
+```text
+RingStats {
+  ring,
+  total,
+  event_type_counts,
+  sensitive_count,
+  superseded_count,
+  average_salience,
+  average_confidence,
+  newest_at,
+  oldest_at,
+  pulse_level,
+  warning_level
+}
+```
+
+The render loop reads derived state, not raw database rows. Raw memory details are loaded only for visible selections.
+
+## Safety
+
+- Forget, redact, promote to heartwood, mark scar, mark seed, supersede, export sensitive, and consolidation require confirmation.
+- Secret-like strings are blocked before storage.
+- Sensitive memories are hidden from recall by default.
+- Sensitive detail rendering is guarded by explicit toggle.
+- Event-stream data is treated as untrusted and policy-safe.
+- The TUI never stores raw chain-of-thought.
+
+## Testing
+
+Required tests:
+
+- Ring stats derive correct counts from seeded memories.
+- Store-watch refresh updates counts after insert/delete/redact.
+- Event-stream updates pulse state before persisted refresh.
+- Full operator actions call Rust storage APIs correctly.
+- Forget/redact confirmations are required.
+- Sensitive memories are hidden by default.
+- Slash commands switch modes correctly.
+- Rendering snapshot tests cover default and exploded-ring modes.
+- Small terminal fallback remains readable.
+
+## Acceptance Criteria
+
+1. `tree-ring tui` launches a Ratatui app from the Rust CLI.
+2. Ambient ASCII tree rings are always visible in the TUI.
+3. Rings light in real time from both store-watch and event-stream updates.
+4. `/rings` opens the exploded-ring view with ring data bubbles.
+5. Search, detail, filters, and ranking explanation are available.
+6. Remember, forget, redact, promote, scar, seed, supersede, consolidate, export, and sync flows exist with guided confirmations where required.
+7. The TUI uses Rust storage, recall, sensitivity, and lifecycle APIs directly.
+8. Python is not required for the TUI.
+9. The design remains framework-agnostic and does not replace DOX or Revolve.
+10. Automated tests cover model derivation, safety gates, event handling, and render snapshots.
+
+## Open Implementation Notes
+
+- Prefer `tree-ring tui` over a separate binary for v1.
+- Keep the event-stream transport local and optional.
+- Start with polling-based store-watch if it reduces cross-platform risk.
+- Use truecolor when available and a 16-color fallback otherwise.
+- Avoid over-animating: pulse should communicate state, not distract from operation.


### PR DESCRIPTION
Summary:
- Add divergent TUI options using the Tree Ring Memory purpose and SCAMPER framing.
- Add the selected Dual-Mode Ring Console design for a Rust-native Ratatui TUI.
- Specify ambient animated ASCII tree rings, exploded ring view, store-watch plus event-stream real-time updates, full operator actions, and Rust-first architecture.

Notes:
- This is a design/spec PR only; no Ratatui implementation yet.
- The design keeps Tree Ring Memory framework-agnostic and does not replace DOX or Revolve.
- .vscode/ remains untracked and was not included.