### PR TITLE
Add Rust Ratatui tree ring console

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,6 +24,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -83,10 +89,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.103"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
+
+[[package]]
+name = "approx"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "atomic"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89cbf775b137e9b968e67227ef7f775587cde3fd31b0d8599dbd0f598a48340"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "bit-set"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
@@ -95,10 +152,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+
+[[package]]
+name = "by_address"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64fa3c856b712db6612c019f14756e64e4bcea13337a6b33b696333a9eaa2d06"
+
+[[package]]
+name = "bytemuck"
+version = "1.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+
+[[package]]
+name = "castaway"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
+dependencies = [
+ "rustversion",
+]
 
 [[package]]
 name = "cc"
@@ -115,6 +202,12 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
@@ -161,7 +254,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -177,10 +270,194 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "compact_str"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dfdd1c2274d9aa354115b09dc9a901d6c5576818cdf70d14cae2bdb47df00ab"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "static_assertions",
+]
+
+[[package]]
+name = "convert_case"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "critical-section"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
+
+[[package]]
+name = "crossterm"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
+dependencies = [
+ "bitflags 2.13.0",
+ "crossterm_winapi",
+ "derive_more",
+ "document-features",
+ "mio",
+ "parking_lot",
+ "rustix",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "csscolorparser"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb2a7d3066da2de787b7f032c736763eb7ae5d355f81a68bab2675a96008b0bf"
+dependencies = [
+ "lab",
+ "phf",
+]
+
+[[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "deltae"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5729f5117e208430e437df2f4843f5e5952997175992d1414f94c57d61e270b4"
+
+[[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+
+[[package]]
+name = "derive_more"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
+
+[[package]]
+name = "document-features"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
+dependencies = [
+ "litrs",
+]
+
+[[package]]
+name = "either"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+
+[[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
@@ -190,6 +467,15 @@ checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
  "windows-sys",
+]
+
+[[package]]
+name = "euclid"
+version = "0.22.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1a05365e3b1c6d1650318537c7460c6923f1abdd272ad6842baa2b509957a06"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -205,16 +491,67 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
+name = "fancy-regex"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b95f7c0680e4142284cf8b22c14a476e87d61b004a3a0861872b32ef7ead40a2"
+dependencies = [
+ "bit-set",
+ "regex",
+]
+
+[[package]]
+name = "fast-srgb8"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd2e7510819d6fbf51a5545c8f922716ecfb14df168a3242f7d33e0239efe6a1"
+
+[[package]]
 name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
+name = "filedescriptor"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e40758ed24c9b2eeb76c35fb0aebc66c626084edd827e07e1552279814c6682d"
+dependencies = [
+ "libc",
+ "thiserror 1.0.69",
+ "winapi",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "finl_unicode"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9844ddc3a6e533d62bba727eb6c28b5d360921d5175e9ff0f1e621a5c590a4d5"
+
+[[package]]
+name = "fixedbitset"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "futures-core"
@@ -241,6 +578,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -248,7 +607,7 @@ checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 6.0.0",
 ]
 
 [[package]]
@@ -261,12 +620,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
+]
+
+[[package]]
 name = "hashlink"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
 dependencies = [
- "hashbrown",
+ "hashbrown 0.14.5",
 ]
 
 [[package]]
@@ -274,6 +655,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "iana-time-zone"
@@ -300,6 +687,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "indoc"
 version = "2.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -309,10 +702,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "instability"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eb2d60ef19920a3a9193c3e371f726ec1dafc045dac788d0fb3704272458971"
+dependencies = [
+ "darling",
+ "indoc",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itoa"
@@ -332,10 +747,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "kasuari"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bde5057d6143cc94e861d90f591b9303d6716c6b9602309150bd068853c10899"
+dependencies = [
+ "hashbrown 0.16.1",
+ "portable-atomic",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "lab"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf36173d4167ed999940f804952e6b08197cae5ad5d572eb4db150ce8ad5d58f"
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+
+[[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libsqlite3-sys"
@@ -349,10 +793,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "line-clipping"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f50e8f47623268b5407192d26876c4d7f89d686ca130fdc53bced4814cd29f8"
+dependencies = [
+ "bitflags 2.13.0",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
+name = "litrs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
+
+[[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
 
 [[package]]
 name = "log"
@@ -361,10 +829,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
+name = "lru"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a860605968fce16869fd239cf4237a82f3ac470723415db603b0e8b6c8d4fb9"
+dependencies = [
+ "hashbrown 0.17.1",
+]
+
+[[package]]
+name = "mac_address"
+version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0aeb26bf5e836cc1c341c8106051b573f1766dfa05aa87f0b98be5e51b02303"
+dependencies = [
+ "nix",
+ "winapi",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
+
+[[package]]
+name = "memmem"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a64a92489e2744ce060c349162be1c5f33c6969234104dbd99ddb5feb08b8c15"
 
 [[package]]
 name = "memoffset"
@@ -376,12 +869,79 @@ dependencies = [
 ]
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "mio"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
+dependencies = [
+ "libc",
+ "log",
+ "wasi",
+ "windows-sys",
+]
+
+[[package]]
+name = "nix"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+dependencies = [
+ "bitflags 2.13.0",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+ "memoffset",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
+
+[[package]]
+name = "num-conv"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
+
+[[package]]
+name = "num-derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "num_threads"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -395,6 +955,156 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "ordered-float"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bb71e1b3fa6ca1c61f383464aaf2bb0e2f8e772a1f01d486832464de363b951"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "palette"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cbf71184cc5ecc2e4e1baccdb21026c20e5fc3dcf63028a086131b3ab00b6e6"
+dependencies = [
+ "approx",
+ "fast-srgb8",
+ "libm",
+ "palette_derive",
+]
+
+[[package]]
+name = "palette_derive"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5030daf005bface118c096f510ffb781fc28f9ab6a32ab224d8631be6851d30"
+dependencies = [
+ "by_address",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link",
+]
+
+[[package]]
+name = "pest"
+version = "2.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47627dd7305c6a2d6c8c6bcd24c5a4c17dbbf425f4f9c5313e724b38fc9782e9"
+dependencies = [
+ "memchr",
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b4254325ecad416ab689e27ba51da03ba01a9632bc6e108f5fe7c3c4ad29d58"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c4c0e91ead7a8f7acecbca6f003fc2e8282b1dbe2dd9c9d2f16aba42995e0a7"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9744bc48116fee06334924bb5f2bad41eed5e89bd26e29b0b799f9a3f82c210"
+dependencies = [
+ "pest",
+]
+
+[[package]]
+name = "phf"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
+dependencies = [
+ "phf_macros",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
+dependencies = [
+ "phf_shared",
+ "rand",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -413,6 +1123,12 @@ name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "proc-macro2"
@@ -470,7 +1186,7 @@ dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -483,7 +1199,7 @@ dependencies = [
  "proc-macro2",
  "pyo3-build-config",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -497,9 +1213,140 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
+dependencies = [
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+
+[[package]]
+name = "ratatui"
+version = "0.30.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3274ba0a2c5e1bcad2a2005d20f4dc59dad26b2eb0940fb094500dba4099d57d"
+dependencies = [
+ "instability",
+ "ratatui-core",
+ "ratatui-crossterm",
+ "ratatui-macros",
+ "ratatui-termina",
+ "ratatui-termwiz",
+ "ratatui-widgets",
+ "serde",
+]
+
+[[package]]
+name = "ratatui-core"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbb175c433c8e28a809d1f5773a2ae96e68c0ce40db865cbab1020bf33ae479c"
+dependencies = [
+ "bitflags 2.13.0",
+ "compact_str",
+ "critical-section",
+ "hashbrown 0.17.1",
+ "itertools",
+ "kasuari",
+ "lru",
+ "palette",
+ "serde",
+ "strum",
+ "thiserror 2.0.18",
+ "unicode-segmentation",
+ "unicode-truncate",
+ "unicode-width",
+]
+
+[[package]]
+name = "ratatui-crossterm"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567584a3b0e6a8203c23de40b4861497266725eb5363dbfd18a1edd603cca9f0"
+dependencies = [
+ "cfg-if",
+ "crossterm",
+ "instability",
+ "ratatui-core",
+]
+
+[[package]]
+name = "ratatui-macros"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed7dc68daa7498a43e4d68e0eb078427e10c38fbcfbb1e42d955f1fa2140d814"
+dependencies = [
+ "ratatui-core",
+ "ratatui-widgets",
+]
+
+[[package]]
+name = "ratatui-termina"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0bf912d9e66f057a759d92e386a280ea886b352ab757d6ac4d653c7ed2c43c2"
+dependencies = [
+ "instability",
+ "ratatui-core",
+ "termina",
+]
+
+[[package]]
+name = "ratatui-termwiz"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf03e0380b7744054d6cb74224fe3adf062a029754933f575ca1e3b4c2ce977"
+dependencies = [
+ "ratatui-core",
+ "termwiz",
+]
+
+[[package]]
+name = "ratatui-widgets"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66e3d19bcc9130ca376277d93b60767ff121ace3be06f5f95f81dd68956407d1"
+dependencies = [
+ "bitflags 2.13.0",
+ "hashbrown 0.17.1",
+ "indoc",
+ "instability",
+ "itertools",
+ "line-clipping",
+ "ratatui-core",
+ "serde",
+ "strum",
+ "time",
+ "unicode-segmentation",
+ "unicode-width",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags 2.13.0",
+]
 
 [[package]]
 name = "regex"
@@ -536,7 +1383,7 @@ version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7753b721174eb8ff87a9a0e799e2d7bc3749323e773db92e0984debb00019d6e"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "fallible-iterator",
  "fallible-streaming-iterator",
  "hashlink",
@@ -545,12 +1392,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -562,6 +1418,24 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -590,7 +1464,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -607,10 +1481,58 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "shlex"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
+name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
+dependencies = [
+ "libc",
+ "mio",
+ "signal-hook",
+]
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
+
+[[package]]
+name = "siphasher"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
 name = "slab"
@@ -625,10 +1547,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
 
 [[package]]
 name = "syn"
@@ -654,10 +1614,86 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
  "windows-sys",
+]
+
+[[package]]
+name = "termina"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9048a889effe34a5cddee0af7f53285198b16dca3be510858d38dfdb3e62a04e"
+dependencies = [
+ "bitflags 2.13.0",
+ "parking_lot",
+ "rustix",
+ "signal-hook",
+ "windows-sys",
+]
+
+[[package]]
+name = "terminfo"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4ea810f0692f9f51b382fff5893887bb4580f5fa246fde546e0b13e7fcee662"
+dependencies = [
+ "fnv",
+ "nom",
+ "phf",
+ "phf_codegen",
+]
+
+[[package]]
+name = "termios"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "411c5bf740737c7918b8b1fe232dca4dc9f8e754b8ad5e20966814001ed0ac6b"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "termwiz"
+version = "0.23.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4676b37242ccbd1aabf56edb093a4827dc49086c0ffd764a5705899e0f35f8f7"
+dependencies = [
+ "anyhow",
+ "base64",
+ "bitflags 2.13.0",
+ "fancy-regex",
+ "filedescriptor",
+ "finl_unicode",
+ "fixedbitset",
+ "hex",
+ "lazy_static",
+ "libc",
+ "log",
+ "memmem",
+ "nix",
+ "num-derive",
+ "num-traits",
+ "ordered-float",
+ "pest",
+ "pest_derive",
+ "phf",
+ "sha2",
+ "signal-hook",
+ "siphasher",
+ "terminfo",
+ "termios",
+ "thiserror 1.0.69",
+ "ucd-trie",
+ "unicode-segmentation",
+ "vtparse",
+ "wezterm-bidi",
+ "wezterm-blob-leases",
+ "wezterm-color-types",
+ "wezterm-dynamic",
+ "wezterm-input-types",
+ "winapi",
 ]
 
 [[package]]
@@ -666,7 +1702,16 @@ version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl 2.0.18",
 ]
 
 [[package]]
@@ -677,14 +1722,48 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "time"
+version = "0.3.53"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18dfaaeddcb932337b5e7866ee7d0ce9b76d2fd092997146f187ec09b4558a50"
+dependencies = [
+ "deranged",
+ "libc",
+ "num-conv",
+ "num_threads",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "tree-ring-memory-cli"
 version = "0.3.0"
 dependencies = [
  "clap",
+ "ratatui",
+ "serde",
  "serde_json",
  "tempfile",
  "tree-ring-memory-core",
@@ -700,7 +1779,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.69",
  "uuid",
 ]
 
@@ -728,10 +1807,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "typenum"
+version = "1.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
+
+[[package]]
+name = "unicode-truncate"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16b380a1238663e5f8a691f9039c73e1cdae598a30e9855f541d29b08b53e9a5"
+dependencies = [
+ "itertools",
+ "unicode-segmentation",
+ "unicode-width",
+]
+
+[[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
 name = "unindent"
@@ -751,7 +1865,8 @@ version = "1.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf80a72845275afea99e7f2b434723d3bc7e38470fcd1c7ed39a599c73319a53"
 dependencies = [
- "getrandom",
+ "atomic",
+ "getrandom 0.4.3",
  "js-sys",
  "wasm-bindgen",
 ]
@@ -767,6 +1882,30 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "vtparse"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d9b2acfb050df409c972a37d3b8e08cdea3bddb0c09db9d53137e504cfabed0"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasip2"
+version = "1.0.4+wasi-0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
+dependencies = [
+ "wit-bindgen",
+]
 
 [[package]]
 name = "wasm-bindgen"
@@ -800,7 +1939,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
  "wasm-bindgen-shared",
 ]
 
@@ -812,6 +1951,100 @@ checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
 dependencies = [
  "unicode-ident",
 ]
+
+[[package]]
+name = "wezterm-bidi"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0a6e355560527dd2d1cf7890652f4f09bb3433b6aadade4c9b5ed76de5f3ec"
+dependencies = [
+ "log",
+ "wezterm-dynamic",
+]
+
+[[package]]
+name = "wezterm-blob-leases"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "692daff6d93d94e29e4114544ef6d5c942a7ed998b37abdc19b17136ea428eb7"
+dependencies = [
+ "getrandom 0.3.4",
+ "mac_address",
+ "sha2",
+ "thiserror 1.0.69",
+ "uuid",
+]
+
+[[package]]
+name = "wezterm-color-types"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7de81ef35c9010270d63772bebef2f2d6d1f2d20a983d27505ac850b8c4b4296"
+dependencies = [
+ "csscolorparser",
+ "deltae",
+ "lazy_static",
+ "wezterm-dynamic",
+]
+
+[[package]]
+name = "wezterm-dynamic"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f2ab60e120fd6eaa68d9567f3226e876684639d22a4219b313ff69ec0ccd5ac"
+dependencies = [
+ "log",
+ "ordered-float",
+ "strsim",
+ "thiserror 1.0.69",
+ "wezterm-dynamic-derive",
+]
+
+[[package]]
+name = "wezterm-dynamic-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46c0cf2d539c645b448eaffec9ec494b8b19bd5077d9e58cb1ae7efece8d575b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "wezterm-input-types"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7012add459f951456ec9d6c7e6fc340b1ce15d6fc9629f8c42853412c029e57e"
+dependencies = [
+ "bitflags 1.3.2",
+ "euclid",
+ "lazy_static",
+ "serde",
+ "wezterm-dynamic",
+]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"
@@ -834,7 +2067,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -845,7 +2078,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -882,6 +2115,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
 name = "zerocopy"
 version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -898,7 +2137,7 @@ checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,3 +27,4 @@ thiserror = "1"
 uuid = { version = "1", features = ["v4"] }
 pyo3 = { version = "0.22", features = ["abi3-py311"] }
 pyo3-build-config = { version = "0.22" }
+ratatui = "0.30.2"

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Tree Ring Memory is in protocol-preview status.
 - v0.1 provides a local Python reference library with SQLite storage and no required cloud services.
 - v0.2 moved durable behavior into a Rust core while preserving Python compatibility.
 - v0.3 makes the public Python facade Rust-first when the optional PyO3 native module is installed.
+- The current Rust branch adds a Ratatui operator console behind `tree-ring tui`.
 
 The Rust workspace currently includes:
 
@@ -113,6 +114,42 @@ tree-ring forget mem_example --mode delete --reason "example cleanup"
 
 The CLI stores memory in `.tree-ring/` by default.
 
+## Terminal Console Preview
+
+The Rust CLI includes a framework-agnostic Ratatui console for humans and agent
+operators working from a terminal:
+
+```bash
+tree-ring tui
+tree-ring --root .tree-ring tui --event-stream ./tree-ring-events.jsonl --tick-ms 150
+```
+
+The console keeps an animated ASCII tree-ring cross-section visible at all
+times. Store-watch polling updates persisted counts from SQLite, while the
+optional event stream lights rings in real time without treating stream events
+as durable truth.
+
+Useful keys and commands:
+
+- `s` focuses search, `/` opens the slash command palette, `r` opens exploded
+  ring view, `q` quits.
+- `i` toggles sensitive-memory visibility, `u` toggles superseded-memory
+  visibility.
+- Slash commands include `/rings`, `/search <query>`, `/remember <summary>`,
+  `/forget`, `/redact`, `/promote`, `/scar`, `/seed`, `/supersede <old_id>`,
+  `/consolidate`, `/export`, `/sync`, `/stream`, and `/watch`.
+
+Destructive or authority-changing operations are confirmation-gated. Sensitive
+details stay hidden by default, and secret-like memory is blocked before
+storage.
+
+Event stream lines are local JSONL objects. They are display signals only:
+
+```json
+{"event":"remembered","ring":"cambium","label":"Stored project lesson"}
+{"event":"policy_blocked","ring":"scar","label":"Secret-like memory blocked"}
+```
+
 ## Development Checks
 
 ```bash
@@ -139,6 +176,8 @@ latency of 250 ms for the synthetic workload.
 - `docs/superpowers/plans/2026-07-05-tree-ring-memory-rust-core-v0-2-implementation-plan.md`
 - `docs/superpowers/specs/2026-07-05-tree-ring-memory-rust-python-bindings-v0-3-design.md`
 - `docs/superpowers/plans/2026-07-05-tree-ring-memory-rust-python-bindings-v0-3-implementation-plan.md`
+- `docs/superpowers/specs/2026-07-05-tree-ring-memory-ratatui-tui-design.md`
+- `docs/superpowers/plans/2026-07-05-tree-ring-memory-ratatui-tui-implementation-plan.md`
 
 ## Agent Workflow Integration
 

--- a/crates/tree-ring-memory-cli/Cargo.toml
+++ b/crates/tree-ring-memory-cli/Cargo.toml
@@ -12,6 +12,8 @@ path = "src/main.rs"
 
 [dependencies]
 clap.workspace = true
+ratatui.workspace = true
+serde.workspace = true
 serde_json.workspace = true
 tree-ring-memory-core = { path = "../tree-ring-memory-core" }
 tree-ring-memory-sqlite = { path = "../tree-ring-memory-sqlite" }

--- a/crates/tree-ring-memory-cli/src/main.rs
+++ b/crates/tree-ring-memory-cli/src/main.rs
@@ -5,6 +5,8 @@ use tree_ring_memory_core::sensitivity::SensitivityGuard;
 use tree_ring_memory_core::MemoryEvent;
 use tree_ring_memory_sqlite::{MemoryRetriever, SQLiteMemoryStore};
 
+mod tui;
+
 #[derive(Debug, Parser)]
 #[command(name = "tree-ring", about = "Local tree-ring memory for AI agents.")]
 struct Cli {
@@ -52,6 +54,17 @@ enum Command {
         #[arg(long)]
         reason: String,
     },
+    #[command(about = "open the Rust-native Tree Ring Memory terminal console")]
+    Tui {
+        #[arg(long, help = "optional JSONL event stream to light rings in real time")]
+        event_stream: Option<PathBuf>,
+        #[arg(
+            long,
+            default_value_t = 250,
+            help = "animation and refresh cadence in milliseconds"
+        )]
+        tick_ms: u64,
+    },
 }
 
 #[derive(Debug, Clone, clap::ValueEnum)]
@@ -72,6 +85,18 @@ fn main() -> std::process::ExitCode {
 
 fn run(cli: Cli) -> Result<(), String> {
     let db_path = cli.root.join("memory.sqlite");
+
+    if let Command::Tui {
+        event_stream,
+        tick_ms,
+    } = cli.command
+    {
+        if cli.json {
+            return Err("--json is not supported with the interactive TUI".to_string());
+        }
+        return tui::run(cli.root, event_stream, tick_ms);
+    }
+
     let mut store = SQLiteMemoryStore::open(&db_path).map_err(|err| err.to_string())?;
 
     match cli.command {
@@ -189,6 +214,7 @@ fn run(cli: Cli) -> Result<(), String> {
                 println!("Tree Ring Memory forget complete: {memory_id}");
             }
         }
+        Command::Tui { .. } => unreachable!("tui returns before opening the scriptable store"),
     }
     Ok(())
 }
@@ -325,5 +351,48 @@ mod tests {
 
         assert!(hidden.is_empty());
         assert_eq!(visible[0].memory.sensitivity, "health");
+    }
+
+    #[test]
+    fn parses_tui_command() {
+        let cli = Cli::try_parse_from([
+            "tree-ring",
+            "--root",
+            ".memory",
+            "tui",
+            "--event-stream",
+            "events.jsonl",
+            "--tick-ms",
+            "125",
+        ])
+        .unwrap();
+
+        match cli.command {
+            Command::Tui {
+                event_stream,
+                tick_ms,
+            } => {
+                assert_eq!(event_stream.unwrap(), PathBuf::from("events.jsonl"));
+                assert_eq!(tick_ms, 125);
+            }
+            _ => panic!("expected tui command"),
+        }
+    }
+
+    #[test]
+    fn tui_rejects_json_mode_before_terminal_start() {
+        let dir = tempdir().unwrap();
+
+        let err = run(Cli {
+            root: dir.path().join(".tree-ring"),
+            json: true,
+            command: Command::Tui {
+                event_stream: None,
+                tick_ms: 250,
+            },
+        })
+        .unwrap_err();
+
+        assert!(err.contains("--json is not supported"));
     }
 }

--- a/crates/tree-ring-memory-cli/src/tui/actions.rs
+++ b/crates/tree-ring-memory-cli/src/tui/actions.rs
@@ -1,0 +1,83 @@
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ActionKind {
+    Delete,
+    Redact,
+    ChangeRing { ring: String, event_type: String },
+    Supersede { old_id: String, new_id: String },
+    Placeholder { command: String },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PendingAction {
+    pub kind: ActionKind,
+    pub memory_id: Option<String>,
+    pub summary: String,
+}
+
+impl PendingAction {
+    pub fn delete(memory_id: String, summary: String) -> Self {
+        Self {
+            kind: ActionKind::Delete,
+            memory_id: Some(memory_id),
+            summary: format!("Forget memory: {summary}"),
+        }
+    }
+
+    pub fn redact(memory_id: String, summary: String) -> Self {
+        Self {
+            kind: ActionKind::Redact,
+            memory_id: Some(memory_id),
+            summary: format!("Redact memory: {summary}"),
+        }
+    }
+
+    pub fn change_ring(memory_id: String, summary: String, ring: &str, event_type: &str) -> Self {
+        Self {
+            kind: ActionKind::ChangeRing {
+                ring: ring.to_string(),
+                event_type: event_type.to_string(),
+            },
+            memory_id: Some(memory_id),
+            summary: format!("Mark as {ring}: {summary}"),
+        }
+    }
+
+    pub fn supersede(old_id: String, new_id: String) -> Self {
+        let summary = format!("Supersede {old_id} with selected memory {new_id}");
+        Self {
+            kind: ActionKind::Supersede {
+                old_id: old_id.clone(),
+                new_id: new_id.clone(),
+            },
+            memory_id: Some(new_id),
+            summary,
+        }
+    }
+
+    pub fn placeholder(command: &str) -> Self {
+        Self {
+            kind: ActionKind::Placeholder {
+                command: command.to_string(),
+            },
+            memory_id: None,
+            summary: format!("Run {command} maintenance flow"),
+        }
+    }
+
+    pub fn confirmation_prompt(&self) -> String {
+        format!("{} - press y to confirm, n/Esc to cancel", self.summary)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn dangerous_actions_are_explicit_pending_values() {
+        let pending = PendingAction::delete("mem_1".to_string(), "Bad memory".to_string());
+
+        assert!(pending.confirmation_prompt().contains("press y"));
+        assert_eq!(pending.memory_id.as_deref(), Some("mem_1"));
+    }
+}

--- a/crates/tree-ring-memory-cli/src/tui/app.rs
+++ b/crates/tree-ring-memory-cli/src/tui/app.rs
@@ -1,0 +1,532 @@
+use std::path::PathBuf;
+
+use ratatui::crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+use tree_ring_memory_core::{now_iso, MemoryEvent, SensitivityGuard};
+use tree_ring_memory_sqlite::{MemoryRetriever, RecallResult, SQLiteMemoryStore};
+
+use super::actions::{ActionKind, PendingAction};
+use super::input::{parse_slash_command, SlashCommand};
+use super::model::DashboardStats;
+use super::store_watch::StoreWatcher;
+use super::stream::{EventStreamReader, LiveEvent};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AppMode {
+    Default,
+    Exploded,
+    Command,
+    Search,
+    Stream,
+    Watch,
+}
+
+pub struct App {
+    pub store: SQLiteMemoryStore,
+    watcher: StoreWatcher,
+    pub dashboard: DashboardStats,
+    pub memories: Vec<MemoryEvent>,
+    pub results: Vec<RecallResult>,
+    pub selected_result: usize,
+    pub selected_ring: usize,
+    pub mode: AppMode,
+    pub command_buffer: String,
+    pub search_query: String,
+    pub include_sensitive: bool,
+    pub include_superseded: bool,
+    pub pending_action: Option<PendingAction>,
+    pub status: String,
+    pub live_events: Vec<LiveEvent>,
+    event_stream: Option<EventStreamReader>,
+    pub tick: u64,
+    pub should_quit: bool,
+}
+
+impl App {
+    pub fn new(root: PathBuf, event_stream_path: Option<PathBuf>) -> Result<Self, String> {
+        let db_path = root.join("memory.sqlite");
+        let store = SQLiteMemoryStore::open(&db_path).map_err(|err| err.to_string())?;
+        let mut app = Self {
+            store,
+            watcher: StoreWatcher::new(),
+            dashboard: DashboardStats::empty(),
+            memories: Vec::new(),
+            results: Vec::new(),
+            selected_result: 0,
+            selected_ring: 0,
+            mode: AppMode::Default,
+            command_buffer: String::new(),
+            search_query: String::new(),
+            include_sensitive: false,
+            include_superseded: false,
+            pending_action: None,
+            status: format!("Store {}", db_path.display()),
+            live_events: Vec::new(),
+            event_stream: event_stream_path.map(EventStreamReader::new),
+            tick: 0,
+            should_quit: false,
+        };
+        app.refresh_store()?;
+        Ok(app)
+    }
+
+    pub fn tick(&mut self) -> Result<(), String> {
+        self.tick = self.tick.wrapping_add(1);
+        self.dashboard.decay_pulses();
+        self.refresh_store()?;
+        self.read_stream_events()?;
+        Ok(())
+    }
+
+    pub fn refresh_store(&mut self) -> Result<(), String> {
+        let snapshot = self.watcher.refresh(&self.store)?;
+        self.dashboard = snapshot.dashboard;
+        self.memories = snapshot
+            .memories
+            .into_iter()
+            .filter(|memory| self.include_superseded || memory.superseded_by.is_none())
+            .filter(|memory| self.include_sensitive || memory.sensitivity == "normal")
+            .collect();
+        if !self.search_query.trim().is_empty() {
+            self.run_search()?;
+        }
+        self.clamp_selection();
+        Ok(())
+    }
+
+    pub fn read_stream_events(&mut self) -> Result<(), String> {
+        let Some(stream) = &mut self.event_stream else {
+            return Ok(());
+        };
+        for event in stream.read_new_events()? {
+            if let Some(ring) = event.ring.as_deref() {
+                self.dashboard.pulse_ring(ring, 1.0);
+            }
+            self.status = format!("event: {}", event.safe_label());
+            self.live_events.push(event);
+        }
+        if self.live_events.len() > 8 {
+            let trim = self.live_events.len() - 8;
+            self.live_events.drain(0..trim);
+        }
+        Ok(())
+    }
+
+    pub fn handle_key(&mut self, key: KeyEvent) -> Result<(), String> {
+        if self.pending_action.is_some() {
+            return self.handle_pending_key(key);
+        }
+        match self.mode {
+            AppMode::Command => self.handle_command_key(key),
+            AppMode::Search => self.handle_search_key(key),
+            _ => self.handle_navigation_key(key),
+        }
+    }
+
+    fn handle_pending_key(&mut self, key: KeyEvent) -> Result<(), String> {
+        match key.code {
+            KeyCode::Char('y') | KeyCode::Char('Y') => self.confirm_pending_action(),
+            KeyCode::Char('n') | KeyCode::Char('N') | KeyCode::Esc => {
+                self.pending_action = None;
+                self.status = "action cancelled".to_string();
+                Ok(())
+            }
+            _ => Ok(()),
+        }
+    }
+
+    fn handle_command_key(&mut self, key: KeyEvent) -> Result<(), String> {
+        match key.code {
+            KeyCode::Esc => {
+                self.mode = AppMode::Default;
+                self.command_buffer.clear();
+            }
+            KeyCode::Enter => {
+                let command = self.command_buffer.clone();
+                self.command_buffer.clear();
+                self.mode = AppMode::Default;
+                self.execute_slash_command(&command)?;
+            }
+            KeyCode::Backspace => {
+                self.command_buffer.pop();
+            }
+            KeyCode::Char(character) => self.command_buffer.push(character),
+            _ => {}
+        }
+        Ok(())
+    }
+
+    fn handle_search_key(&mut self, key: KeyEvent) -> Result<(), String> {
+        match key.code {
+            KeyCode::Esc => self.mode = AppMode::Default,
+            KeyCode::Enter => self.run_search()?,
+            KeyCode::Down | KeyCode::Char('j') => self.move_result(1),
+            KeyCode::Up | KeyCode::Char('k') => self.move_result(-1),
+            KeyCode::Backspace => {
+                self.search_query.pop();
+                self.run_search()?;
+            }
+            KeyCode::Char(character) => {
+                self.search_query.push(character);
+                self.run_search()?;
+            }
+            _ => {}
+        }
+        Ok(())
+    }
+
+    fn handle_navigation_key(&mut self, key: KeyEvent) -> Result<(), String> {
+        if key.modifiers.contains(KeyModifiers::CONTROL) && key.code == KeyCode::Char('c') {
+            self.should_quit = true;
+            return Ok(());
+        }
+        match key.code {
+            KeyCode::Char('q') => self.should_quit = true,
+            KeyCode::Char('/') => {
+                self.mode = AppMode::Command;
+                self.command_buffer.clear();
+            }
+            KeyCode::Char('s') => self.mode = AppMode::Search,
+            KeyCode::Char('r') => self.mode = AppMode::Exploded,
+            KeyCode::Char('i') => {
+                self.include_sensitive = !self.include_sensitive;
+                self.status = format!("include sensitive: {}", self.include_sensitive);
+                self.run_search()?;
+            }
+            KeyCode::Char('u') => {
+                self.include_superseded = !self.include_superseded;
+                self.status = format!("include superseded: {}", self.include_superseded);
+                self.refresh_store()?;
+            }
+            KeyCode::Esc => self.mode = AppMode::Default,
+            KeyCode::Tab | KeyCode::Right => self.move_ring(1),
+            KeyCode::BackTab | KeyCode::Left => self.move_ring(-1),
+            KeyCode::Down | KeyCode::Char('j') => self.move_result(1),
+            KeyCode::Up | KeyCode::Char('k') => self.move_result(-1),
+            _ => {}
+        }
+        Ok(())
+    }
+
+    pub fn execute_slash_command(&mut self, input: &str) -> Result<(), String> {
+        match parse_slash_command(input) {
+            SlashCommand::Rings => self.mode = AppMode::Exploded,
+            SlashCommand::Search(query) => {
+                self.mode = AppMode::Search;
+                if !query.is_empty() {
+                    self.search_query = query;
+                    self.run_search()?;
+                }
+            }
+            SlashCommand::Remember(summary) => self.remember_summary(summary)?,
+            SlashCommand::Forget => self.pending_for_selected(PendingKind::Delete),
+            SlashCommand::Redact => self.pending_for_selected(PendingKind::Redact),
+            SlashCommand::Promote => self.pending_for_selected(PendingKind::Promote),
+            SlashCommand::Scar => self.pending_for_selected(PendingKind::Scar),
+            SlashCommand::Seed => self.pending_for_selected(PendingKind::Seed),
+            SlashCommand::Supersede(old_id) => {
+                if old_id.is_empty() {
+                    self.status = "supersede requires an old memory id".to_string();
+                } else if let Some(memory) = self.selected_memory() {
+                    self.pending_action = Some(PendingAction::supersede(old_id, memory.id.clone()));
+                } else {
+                    self.status = "select a replacement memory first".to_string();
+                }
+            }
+            SlashCommand::Consolidate => {
+                self.pending_action = Some(PendingAction::placeholder("consolidate"))
+            }
+            SlashCommand::Export => {
+                self.pending_action = Some(PendingAction::placeholder("export"))
+            }
+            SlashCommand::Sync => self.pending_action = Some(PendingAction::placeholder("sync")),
+            SlashCommand::Stream => {
+                self.mode = AppMode::Stream;
+                self.status = "showing recent event-stream signals".to_string();
+            }
+            SlashCommand::Watch => {
+                self.mode = AppMode::Watch;
+                self.status = "store-watch polling is active".to_string();
+            }
+            SlashCommand::Unknown(command) => {
+                self.status = if command.is_empty() {
+                    "type a slash command".to_string()
+                } else {
+                    format!("unknown command: {command}")
+                };
+            }
+        }
+        Ok(())
+    }
+
+    fn remember_summary(&mut self, summary: String) -> Result<(), String> {
+        if summary.trim().is_empty() {
+            self.status = "remember requires a summary".to_string();
+            return Ok(());
+        }
+        let mut event =
+            MemoryEvent::new(summary.trim(), "lesson").map_err(|err| err.to_string())?;
+        event.ring = "cambium".to_string();
+        event.source.source_type = "manual".to_string();
+        let guard = SensitivityGuard::default();
+        let detected = guard
+            .detect_memory_event_sensitivity(&event)
+            .map_err(|err| err.to_string())?;
+        if detected != "normal" {
+            event.sensitivity = detected;
+        }
+        event.validate().map_err(|err| err.to_string())?;
+        let id = event.id.clone();
+        self.store.put(&event).map_err(|err| err.to_string())?;
+        self.status = format!("remembered {id}");
+        self.refresh_store()
+    }
+
+    fn pending_for_selected(&mut self, kind: PendingKind) {
+        let Some(memory) = self.selected_memory() else {
+            self.status = "select a memory first".to_string();
+            return;
+        };
+        let summary = memory.summary.clone();
+        let id = memory.id.clone();
+        let event_type = memory.event_type.clone();
+        self.pending_action = Some(match kind {
+            PendingKind::Delete => PendingAction::delete(id, summary),
+            PendingKind::Redact => PendingAction::redact(id, summary),
+            PendingKind::Promote => {
+                PendingAction::change_ring(id, summary, "heartwood", &event_type)
+            }
+            PendingKind::Scar => PendingAction::change_ring(id, summary, "scar", "warning"),
+            PendingKind::Seed => PendingAction::change_ring(id, summary, "seed", "hypothesis"),
+        });
+    }
+
+    fn confirm_pending_action(&mut self) -> Result<(), String> {
+        let Some(pending) = self.pending_action.take() else {
+            return Ok(());
+        };
+        match pending.kind {
+            ActionKind::Delete => {
+                if let Some(memory_id) = pending.memory_id {
+                    self.store
+                        .delete(&memory_id)
+                        .map_err(|err| err.to_string())?;
+                    self.status = format!("forgot {memory_id}");
+                }
+            }
+            ActionKind::Redact => {
+                if let Some(memory_id) = pending.memory_id {
+                    self.store
+                        .redact(&memory_id)
+                        .map_err(|err| err.to_string())?;
+                    self.status = format!("redacted {memory_id}");
+                }
+            }
+            ActionKind::ChangeRing { ring, event_type } => {
+                if let Some(memory_id) = pending.memory_id {
+                    if let Some(mut memory) =
+                        self.store.get(&memory_id).map_err(|err| err.to_string())?
+                    {
+                        memory.ring = ring.clone();
+                        memory.event_type = event_type;
+                        memory.updated_at = now_iso();
+                        if ring == "heartwood" {
+                            memory.retention = "durable".to_string();
+                        }
+                        self.store.put(&memory).map_err(|err| err.to_string())?;
+                        self.status = format!("marked {memory_id} as {ring}");
+                    }
+                }
+            }
+            ActionKind::Supersede { old_id, new_id } => {
+                self.store
+                    .supersede(&old_id, &new_id)
+                    .map_err(|err| err.to_string())?;
+                self.status = format!("superseded {old_id} with {new_id}");
+            }
+            ActionKind::Placeholder { command } => {
+                self.status = format!("{command} is confirmation-gated; backend flow pending");
+            }
+        }
+        self.refresh_store()
+    }
+
+    pub fn run_search(&mut self) -> Result<(), String> {
+        if self.search_query.trim().is_empty() {
+            self.results.clear();
+            self.selected_result = 0;
+            return Ok(());
+        }
+        self.results = MemoryRetriever::new(&self.store)
+            .recall(
+                &self.search_query,
+                None,
+                None,
+                None,
+                None,
+                None,
+                self.include_sensitive,
+                self.include_superseded,
+                12,
+                true,
+            )
+            .map_err(|err| err.to_string())?;
+        for result in &self.results {
+            self.dashboard.pulse_ring(&result.memory.ring, 0.72);
+        }
+        self.clamp_selection();
+        Ok(())
+    }
+
+    pub fn selected_memory(&self) -> Option<&MemoryEvent> {
+        if self.search_query.trim().is_empty() {
+            self.memories.get(self.selected_result)
+        } else {
+            self.results
+                .get(self.selected_result)
+                .map(|result| &result.memory)
+        }
+    }
+
+    fn move_result(&mut self, delta: isize) {
+        let len = self.visible_memory_count();
+        if len == 0 {
+            self.selected_result = 0;
+            return;
+        }
+        self.selected_result = wrap_index(self.selected_result, len, delta);
+    }
+
+    fn move_ring(&mut self, delta: isize) {
+        let len = self.dashboard.rings.len();
+        if len > 0 {
+            self.selected_ring = wrap_index(self.selected_ring, len, delta);
+        }
+    }
+
+    fn clamp_selection(&mut self) {
+        let result_len = self.visible_memory_count();
+        if result_len == 0 {
+            self.selected_result = 0;
+        } else if self.selected_result >= result_len {
+            self.selected_result = result_len - 1;
+        }
+        if !self.dashboard.rings.is_empty() && self.selected_ring >= self.dashboard.rings.len() {
+            self.selected_ring = self.dashboard.rings.len() - 1;
+        }
+    }
+
+    fn visible_memory_count(&self) -> usize {
+        if self.search_query.trim().is_empty() {
+            self.memories.len()
+        } else {
+            self.results.len()
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+enum PendingKind {
+    Delete,
+    Redact,
+    Promote,
+    Scar,
+    Seed,
+}
+
+fn wrap_index(current: usize, len: usize, delta: isize) -> usize {
+    if delta.is_negative() {
+        current.checked_sub(delta.unsigned_abs()).unwrap_or(len - 1)
+    } else {
+        (current + delta as usize) % len
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use ratatui::crossterm::event::{KeyCode, KeyEvent};
+    use tempfile::{tempdir, TempDir};
+
+    use super::*;
+
+    fn app(dir: &TempDir) -> App {
+        App::new(dir.path().join(".tree-ring"), None).unwrap()
+    }
+
+    #[test]
+    fn slash_remember_stores_and_pulses_cambium() {
+        let dir = tempdir().unwrap();
+        let mut app = app(&dir);
+
+        app.execute_slash_command("/remember User likes durable summaries")
+            .unwrap();
+
+        assert_eq!(app.dashboard.total, 1);
+        assert_eq!(app.dashboard.ring("cambium").unwrap().total, 1);
+    }
+
+    #[test]
+    fn secret_like_remember_is_blocked() {
+        let dir = tempdir().unwrap();
+        let mut app = app(&dir);
+
+        let err = app
+            .execute_slash_command("/remember token sk-proj-abcdefghijklmnopqrstuvwxyz1234567890")
+            .unwrap_err();
+
+        assert!(err.contains("blocked"));
+        assert_eq!(app.dashboard.total, 0);
+    }
+
+    #[test]
+    fn dangerous_command_creates_pending_confirmation() {
+        let dir = tempdir().unwrap();
+        let mut app = app(&dir);
+        app.execute_slash_command("/remember Avoid stale UI state")
+            .unwrap();
+
+        app.execute_slash_command("/forget").unwrap();
+
+        assert!(app.pending_action.is_some());
+        assert_eq!(app.dashboard.total, 1);
+    }
+
+    #[test]
+    fn confirmation_executes_delete() {
+        let dir = tempdir().unwrap();
+        let mut app = app(&dir);
+        app.execute_slash_command("/remember Avoid stale UI state")
+            .unwrap();
+        app.execute_slash_command("/forget").unwrap();
+
+        app.handle_key(KeyEvent::new(
+            KeyCode::Char('y'),
+            ratatui::crossterm::event::KeyModifiers::NONE,
+        ))
+        .unwrap();
+
+        assert_eq!(app.dashboard.total, 0);
+    }
+
+    #[test]
+    fn slash_rings_switches_exploded_mode() {
+        let dir = tempdir().unwrap();
+        let mut app = app(&dir);
+
+        app.execute_slash_command("/rings").unwrap();
+
+        assert_eq!(app.mode, AppMode::Exploded);
+    }
+
+    #[test]
+    fn active_search_without_hits_does_not_fall_back_to_browse_selection() {
+        let dir = tempdir().unwrap();
+        let mut app = app(&dir);
+        app.execute_slash_command("/remember Stored memory")
+            .unwrap();
+
+        app.execute_slash_command("/search absent needle").unwrap();
+
+        assert!(app.results.is_empty());
+        assert!(app.selected_memory().is_none());
+    }
+}

--- a/crates/tree-ring-memory-cli/src/tui/event.rs
+++ b/crates/tree-ring-memory-cli/src/tui/event.rs
@@ -1,0 +1,13 @@
+#![allow(dead_code)]
+
+use ratatui::crossterm::event::KeyEvent;
+
+use super::stream::LiveEvent;
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum ConsoleEvent {
+    Tick,
+    Key(KeyEvent),
+    StoreRefresh,
+    Stream(LiveEvent),
+}

--- a/crates/tree-ring-memory-cli/src/tui/input.rs
+++ b/crates/tree-ring-memory-cli/src/tui/input.rs
@@ -1,0 +1,74 @@
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SlashCommand {
+    Rings,
+    Search(String),
+    Remember(String),
+    Forget,
+    Redact,
+    Promote,
+    Scar,
+    Seed,
+    Supersede(String),
+    Consolidate,
+    Export,
+    Sync,
+    Stream,
+    Watch,
+    Unknown(String),
+}
+
+pub fn parse_slash_command(input: &str) -> SlashCommand {
+    let command = input.trim().trim_start_matches('/');
+    let mut parts = command.splitn(2, char::is_whitespace);
+    let name = parts.next().unwrap_or_default().to_ascii_lowercase();
+    let argument = parts.next().unwrap_or_default().trim().to_string();
+
+    match name.as_str() {
+        "rings" => SlashCommand::Rings,
+        "search" => SlashCommand::Search(argument),
+        "remember" => SlashCommand::Remember(argument),
+        "forget" => SlashCommand::Forget,
+        "redact" => SlashCommand::Redact,
+        "promote" => SlashCommand::Promote,
+        "scar" => SlashCommand::Scar,
+        "seed" => SlashCommand::Seed,
+        "supersede" => SlashCommand::Supersede(argument),
+        "consolidate" => SlashCommand::Consolidate,
+        "export" => SlashCommand::Export,
+        "sync" => SlashCommand::Sync,
+        "stream" => SlashCommand::Stream,
+        "watch" => SlashCommand::Watch,
+        "" => SlashCommand::Unknown(String::new()),
+        _ => SlashCommand::Unknown(name),
+    }
+}
+
+pub fn command_help() -> &'static str {
+    "/rings /search <q> /remember <summary> /forget /redact /promote /scar /seed /supersede <old_id> /consolidate /export /sync"
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_search_and_remember_arguments() {
+        assert_eq!(
+            parse_slash_command("/search stale cache"),
+            SlashCommand::Search("stale cache".to_string())
+        );
+        assert_eq!(
+            parse_slash_command("/remember User prefers concise reports"),
+            SlashCommand::Remember("User prefers concise reports".to_string())
+        );
+    }
+
+    #[test]
+    fn parses_dangerous_commands_without_executing_them() {
+        assert_eq!(parse_slash_command("/forget"), SlashCommand::Forget);
+        assert_eq!(
+            parse_slash_command("/supersede mem_old"),
+            SlashCommand::Supersede("mem_old".to_string())
+        );
+    }
+}

--- a/crates/tree-ring-memory-cli/src/tui/mod.rs
+++ b/crates/tree-ring-memory-cli/src/tui/mod.rs
@@ -1,0 +1,47 @@
+mod actions;
+pub mod app;
+mod event;
+mod input;
+mod model;
+mod render;
+mod rings;
+mod store_watch;
+mod stream;
+
+use std::path::PathBuf;
+use std::time::Duration;
+
+use ratatui::crossterm::event as terminal_event;
+
+use app::App;
+
+pub fn run(root: PathBuf, event_stream: Option<PathBuf>, tick_ms: u64) -> Result<(), String> {
+    let tick_rate = Duration::from_millis(tick_ms.clamp(50, 5_000));
+    let mut app = App::new(root, event_stream)?;
+    let mut terminal = ratatui::init();
+    let result = run_loop(&mut terminal, &mut app, tick_rate);
+    ratatui::restore();
+    result
+}
+
+fn run_loop(
+    terminal: &mut ratatui::DefaultTerminal,
+    app: &mut App,
+    tick_rate: Duration,
+) -> Result<(), String> {
+    while !app.should_quit {
+        terminal
+            .draw(|frame| render::render(frame, app))
+            .map_err(|err| err.to_string())?;
+
+        if terminal_event::poll(tick_rate).map_err(|err| err.to_string())? {
+            if let terminal_event::Event::Key(key) =
+                terminal_event::read().map_err(|err| err.to_string())?
+            {
+                app.handle_key(key)?;
+            }
+        }
+        app.tick()?;
+    }
+    Ok(())
+}

--- a/crates/tree-ring-memory-cli/src/tui/model.rs
+++ b/crates/tree-ring-memory-cli/src/tui/model.rs
@@ -1,0 +1,216 @@
+use std::collections::BTreeMap;
+
+use tree_ring_memory_core::models::RINGS;
+use tree_ring_memory_core::MemoryEvent;
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct RingStats {
+    pub ring: String,
+    pub total: usize,
+    pub event_type_counts: BTreeMap<String, usize>,
+    pub sensitive_count: usize,
+    pub superseded_count: usize,
+    pub average_salience: f64,
+    pub average_confidence: f64,
+    pub newest_at: Option<String>,
+    pub oldest_at: Option<String>,
+    pub pulse_level: f64,
+    pub warning_level: f64,
+}
+
+impl RingStats {
+    pub fn empty(ring: &str) -> Self {
+        Self {
+            ring: ring.to_string(),
+            total: 0,
+            event_type_counts: BTreeMap::new(),
+            sensitive_count: 0,
+            superseded_count: 0,
+            average_salience: 0.0,
+            average_confidence: 0.0,
+            newest_at: None,
+            oldest_at: None,
+            pulse_level: 0.0,
+            warning_level: 0.0,
+        }
+    }
+
+    pub fn top_event_types(&self, max: usize) -> Vec<String> {
+        let mut counts: Vec<_> = self.event_type_counts.iter().collect();
+        counts.sort_by(|left, right| right.1.cmp(left.1).then_with(|| left.0.cmp(right.0)));
+        counts
+            .into_iter()
+            .take(max)
+            .map(|(event_type, count)| format!("{event_type}:{count}"))
+            .collect()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct DashboardStats {
+    pub rings: Vec<RingStats>,
+    pub total: usize,
+    pub sensitive_total: usize,
+    pub superseded_total: usize,
+    pub last_refresh: Option<String>,
+}
+
+impl DashboardStats {
+    pub fn empty() -> Self {
+        Self {
+            rings: RINGS.iter().map(|ring| RingStats::empty(ring)).collect(),
+            total: 0,
+            sensitive_total: 0,
+            superseded_total: 0,
+            last_refresh: None,
+        }
+    }
+
+    pub fn from_memories(memories: &[MemoryEvent], previous: Option<&DashboardStats>) -> Self {
+        let mut dashboard = Self::empty();
+        dashboard.last_refresh = Some(tree_ring_memory_core::now_iso());
+
+        for memory in memories {
+            {
+                let Some(stats) = dashboard.ring_mut(&memory.ring) else {
+                    continue;
+                };
+                stats.total += 1;
+                *stats
+                    .event_type_counts
+                    .entry(memory.event_type.clone())
+                    .or_insert(0) += 1;
+                if memory.sensitivity != "normal" {
+                    stats.sensitive_count += 1;
+                }
+                if memory.superseded_by.is_some() {
+                    stats.superseded_count += 1;
+                }
+                stats.average_salience += memory.salience;
+                stats.average_confidence += memory.confidence;
+                track_time(&mut stats.newest_at, &memory.created_at, true);
+                track_time(&mut stats.oldest_at, &memory.created_at, false);
+            }
+
+            if memory.sensitivity != "normal" {
+                dashboard.sensitive_total += 1;
+            }
+            if memory.superseded_by.is_some() {
+                dashboard.superseded_total += 1;
+            }
+            dashboard.total += 1;
+        }
+
+        for stats in &mut dashboard.rings {
+            if stats.total > 0 {
+                stats.average_salience /= stats.total as f64;
+                stats.average_confidence /= stats.total as f64;
+            }
+            stats.warning_level = ring_warning_level(stats);
+            if let Some(previous_stats) = previous.and_then(|previous| previous.ring(&stats.ring)) {
+                if stats.total != previous_stats.total {
+                    stats.pulse_level = 1.0;
+                } else {
+                    stats.pulse_level = previous_stats.pulse_level * 0.82;
+                }
+            }
+        }
+
+        dashboard
+    }
+
+    pub fn ring(&self, ring: &str) -> Option<&RingStats> {
+        self.rings.iter().find(|stats| stats.ring == ring)
+    }
+
+    pub fn ring_mut(&mut self, ring: &str) -> Option<&mut RingStats> {
+        self.rings.iter_mut().find(|stats| stats.ring == ring)
+    }
+
+    pub fn pulse_ring(&mut self, ring: &str, level: f64) {
+        if let Some(stats) = self.ring_mut(ring) {
+            stats.pulse_level = stats.pulse_level.max(level.clamp(0.0, 1.0));
+        }
+    }
+
+    pub fn decay_pulses(&mut self) {
+        for stats in &mut self.rings {
+            stats.pulse_level *= 0.88;
+            if stats.pulse_level < 0.02 {
+                stats.pulse_level = 0.0;
+            }
+        }
+    }
+}
+
+fn ring_warning_level(stats: &RingStats) -> f64 {
+    if stats.ring == "scar" && stats.total > 0 {
+        return 1.0;
+    }
+    if stats.sensitive_count > 0 && stats.total > 0 {
+        return (stats.sensitive_count as f64 / stats.total as f64).clamp(0.25, 1.0);
+    }
+    0.0
+}
+
+fn track_time(target: &mut Option<String>, candidate: &str, newest: bool) {
+    match target {
+        None => *target = Some(candidate.to_string()),
+        Some(current) if newest && candidate > current.as_str() => {
+            *current = candidate.to_string();
+        }
+        Some(current) if !newest && candidate < current.as_str() => {
+            *current = candidate.to_string();
+        }
+        _ => {}
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn event(summary: &str, ring: &str, event_type: &str) -> MemoryEvent {
+        let mut memory = MemoryEvent::new(summary, event_type).unwrap();
+        memory.ring = ring.to_string();
+        memory
+    }
+
+    #[test]
+    fn derives_ring_counts_and_averages() {
+        let mut heartwood = event("Durable preference", "heartwood", "user_preference");
+        heartwood.salience = 0.8;
+        heartwood.confidence = 0.9;
+        let mut scar = event("Avoid stale cache", "scar", "warning");
+        scar.sensitivity = "private".to_string();
+
+        let stats = DashboardStats::from_memories(&[heartwood, scar], None);
+
+        assert_eq!(stats.total, 2);
+        assert_eq!(stats.sensitive_total, 1);
+        assert_eq!(stats.ring("heartwood").unwrap().total, 1);
+        assert_eq!(
+            stats
+                .ring("heartwood")
+                .unwrap()
+                .event_type_counts
+                .get("user_preference"),
+            Some(&1)
+        );
+        assert_eq!(stats.ring("scar").unwrap().warning_level, 1.0);
+    }
+
+    #[test]
+    fn count_deltas_pulse_changed_rings() {
+        let first = DashboardStats::from_memories(&[event("Fresh", "cambium", "lesson")], None);
+        let second = DashboardStats::from_memories(
+            &[
+                event("Fresh", "cambium", "lesson"),
+                event("Another", "cambium", "decision"),
+            ],
+            Some(&first),
+        );
+
+        assert_eq!(second.ring("cambium").unwrap().pulse_level, 1.0);
+    }
+}

--- a/crates/tree-ring-memory-cli/src/tui/render.rs
+++ b/crates/tree-ring-memory-cli/src/tui/render.rs
@@ -1,0 +1,383 @@
+use ratatui::layout::{Constraint, Direction, Layout, Rect};
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, Borders, List, ListItem, Paragraph, Wrap};
+use ratatui::Frame;
+
+use super::app::{App, AppMode};
+use super::input::command_help;
+use super::rings::{ambient_tree_lines, exploded_ring_lines, ring_style};
+
+pub fn render(frame: &mut Frame<'_>, app: &App) {
+    let area = frame.area();
+    if area.width < 72 || area.height < 22 {
+        render_compact(frame, area, app);
+        return;
+    }
+
+    let vertical = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(3),
+            Constraint::Min(12),
+            Constraint::Length(3),
+        ])
+        .split(area);
+
+    render_header(frame, vertical[0], app);
+    render_body(frame, vertical[1], app);
+    render_footer(frame, vertical[2], app);
+
+    if let Some(pending) = &app.pending_action {
+        render_confirmation(
+            frame,
+            centered_rect(70, 22, area),
+            &pending.confirmation_prompt(),
+        );
+    }
+}
+
+fn render_header(frame: &mut Frame<'_>, area: Rect, app: &App) {
+    let mode = match app.mode {
+        AppMode::Default => "ambient",
+        AppMode::Exploded => "exploded",
+        AppMode::Command => "command",
+        AppMode::Search => "search",
+        AppMode::Stream => "stream",
+        AppMode::Watch => "watch",
+    };
+    let header = Paragraph::new(Line::from(vec![
+        Span::styled(
+            "TREE RING MEMORY",
+            Style::default()
+                .fg(Color::LightYellow)
+                .add_modifier(Modifier::BOLD),
+        ),
+        Span::raw(format!("  mode:{mode}")),
+        Span::raw(format!("  total:{}", app.dashboard.total)),
+        Span::raw(format!("  private:{}", app.dashboard.sensitive_total)),
+        Span::raw(format!("  status: {}", app.status)),
+    ]))
+    .block(Block::default().borders(Borders::ALL));
+    frame.render_widget(header, area);
+}
+
+fn render_body(frame: &mut Frame<'_>, area: Rect, app: &App) {
+    let columns = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([Constraint::Percentage(42), Constraint::Percentage(58)])
+        .split(area);
+    let left = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Percentage(64), Constraint::Percentage(36)])
+        .split(columns[0]);
+    let right = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Percentage(54), Constraint::Percentage(46)])
+        .split(columns[1]);
+
+    if app.mode == AppMode::Exploded {
+        render_exploded(frame, left[0], app);
+    } else {
+        render_ambient(frame, left[0], app);
+    }
+    render_ring_hud(frame, left[1], app);
+    render_results(frame, right[0], app);
+    render_detail(frame, right[1], app);
+}
+
+fn render_ambient(frame: &mut Frame<'_>, area: Rect, app: &App) {
+    let paragraph = Paragraph::new(ambient_tree_lines(&app.dashboard, app.tick))
+        .block(
+            Block::default()
+                .title("Ambient Rings")
+                .borders(Borders::ALL),
+        )
+        .wrap(Wrap { trim: false });
+    frame.render_widget(paragraph, area);
+}
+
+fn render_exploded(frame: &mut Frame<'_>, area: Rect, app: &App) {
+    let paragraph = Paragraph::new(exploded_ring_lines(&app.dashboard, app.selected_ring))
+        .block(Block::default().title("/rings").borders(Borders::ALL))
+        .wrap(Wrap { trim: false });
+    frame.render_widget(paragraph, area);
+}
+
+fn render_ring_hud(frame: &mut Frame<'_>, area: Rect, app: &App) {
+    let items: Vec<ListItem<'_>> = app
+        .dashboard
+        .rings
+        .iter()
+        .enumerate()
+        .map(|(index, stats)| {
+            let selected = if index == app.selected_ring { ">" } else { " " };
+            let line = Line::from(vec![
+                Span::raw(selected),
+                Span::styled(format!(" {:<10}", stats.ring), ring_style(stats)),
+                Span::raw(format!(
+                    " {:>4} avg {:.2}/{:.2} private {}",
+                    stats.total,
+                    stats.average_confidence,
+                    stats.average_salience,
+                    stats.sensitive_count
+                )),
+            ]);
+            ListItem::new(line)
+        })
+        .collect();
+    let list = List::new(items).block(Block::default().title("Rings").borders(Borders::ALL));
+    frame.render_widget(list, area);
+}
+
+fn render_results(frame: &mut Frame<'_>, area: Rect, app: &App) {
+    let title = if app.search_query.is_empty() {
+        "Memories".to_string()
+    } else {
+        format!("Results: {}", app.search_query)
+    };
+    let items: Vec<ListItem<'_>> = if app.search_query.is_empty() {
+        app.memories
+            .iter()
+            .enumerate()
+            .take(12)
+            .map(|(index, memory)| {
+                memory_item(
+                    index,
+                    app.selected_result,
+                    &memory.ring,
+                    &memory.summary,
+                    None,
+                )
+            })
+            .collect()
+    } else if app.results.is_empty() {
+        vec![ListItem::new(Line::from(Span::styled(
+            "No matching memory.",
+            Style::default().fg(Color::DarkGray),
+        )))]
+    } else {
+        app.results
+            .iter()
+            .enumerate()
+            .map(|(index, result)| {
+                memory_item(
+                    index,
+                    app.selected_result,
+                    &result.memory.ring,
+                    &result.memory.summary,
+                    Some(result.score),
+                )
+            })
+            .collect()
+    };
+    let list = List::new(items).block(Block::default().title(title).borders(Borders::ALL));
+    frame.render_widget(list, area);
+}
+
+fn memory_item<'a>(
+    index: usize,
+    selected: usize,
+    ring: &str,
+    summary: &str,
+    score: Option<f64>,
+) -> ListItem<'a> {
+    let marker = if index == selected { ">" } else { " " };
+    let score = score
+        .map(|score| format!(" score={score:.3}"))
+        .unwrap_or_default();
+    ListItem::new(Line::from(vec![
+        Span::raw(marker.to_string()),
+        Span::styled(format!(" [{ring}] "), Style::default().fg(Color::LightCyan)),
+        Span::raw(truncate(summary, 80)),
+        Span::styled(score, Style::default().fg(Color::DarkGray)),
+    ]))
+}
+
+fn render_detail(frame: &mut Frame<'_>, area: Rect, app: &App) {
+    let mut lines = Vec::new();
+    if let Some(memory) = app.selected_memory() {
+        let details = if memory.sensitivity == "normal" || app.include_sensitive {
+            truncate(&memory.details, 220)
+        } else {
+            "[sensitive details hidden]".to_string()
+        };
+        lines.push(Line::from(vec![
+            Span::styled("id ", Style::default().fg(Color::DarkGray)),
+            Span::raw(memory.id.clone()),
+        ]));
+        lines.push(Line::from(vec![
+            Span::styled("ring ", Style::default().fg(Color::DarkGray)),
+            Span::raw(memory.ring.clone()),
+            Span::styled(" type ", Style::default().fg(Color::DarkGray)),
+            Span::raw(memory.event_type.clone()),
+        ]));
+        lines.push(Line::from(vec![
+            Span::styled("confidence ", Style::default().fg(Color::DarkGray)),
+            Span::raw(format!("{:.2}", memory.confidence)),
+            Span::styled(" salience ", Style::default().fg(Color::DarkGray)),
+            Span::raw(format!("{:.2}", memory.salience)),
+        ]));
+        lines.push(Line::from(vec![
+            Span::styled("source ", Style::default().fg(Color::DarkGray)),
+            Span::raw(format!(
+                "{} {}",
+                memory.source.source_type, memory.source.ref_
+            )),
+        ]));
+        lines.push(Line::from(""));
+        lines.push(Line::from(truncate(&memory.summary, 160)));
+        if !details.is_empty() {
+            lines.push(Line::from(""));
+            lines.push(Line::from(details));
+        }
+    } else {
+        lines.push(Line::from("No matching memory yet."));
+        lines.push(Line::from("Use /remember <summary> or /search <query>."));
+    }
+
+    if app.mode == AppMode::Command {
+        lines.push(Line::from(""));
+        lines.push(Line::from(vec![
+            Span::styled("/", Style::default().fg(Color::LightYellow)),
+            Span::raw(app.command_buffer.clone()),
+        ]));
+    } else if app.mode == AppMode::Search {
+        lines.push(Line::from(""));
+        lines.push(Line::from(vec![
+            Span::styled("search ", Style::default().fg(Color::LightYellow)),
+            Span::raw(app.search_query.clone()),
+        ]));
+    }
+
+    if !app.live_events.is_empty() {
+        lines.push(Line::from(""));
+        lines.push(Line::from(Span::styled(
+            "live",
+            Style::default()
+                .fg(Color::LightMagenta)
+                .add_modifier(Modifier::BOLD),
+        )));
+        for event in app.live_events.iter().rev().take(3) {
+            lines.push(Line::from(format!(
+                "{} {}",
+                event.ring.as_deref().unwrap_or("-"),
+                event.safe_label()
+            )));
+        }
+    }
+
+    let paragraph = Paragraph::new(lines)
+        .block(
+            Block::default()
+                .title("Detail / Actions")
+                .borders(Borders::ALL),
+        )
+        .wrap(Wrap { trim: true });
+    frame.render_widget(paragraph, area);
+}
+
+fn render_footer(frame: &mut Frame<'_>, area: Rect, app: &App) {
+    let text = format!(
+        "q quit | / command | s search | r rings | i sensitive:{} | u superseded:{} | {}",
+        app.include_sensitive,
+        app.include_superseded,
+        command_help()
+    );
+    let footer = Paragraph::new(text)
+        .block(Block::default().title("Actions").borders(Borders::ALL))
+        .wrap(Wrap { trim: true });
+    frame.render_widget(footer, area);
+}
+
+fn render_confirmation(frame: &mut Frame<'_>, area: Rect, prompt: &str) {
+    frame.render_widget(ratatui::widgets::Clear, area);
+    let paragraph = Paragraph::new(vec![
+        Line::from(Span::styled(
+            "Confirm Tree Ring Memory action",
+            Style::default()
+                .fg(Color::LightRed)
+                .add_modifier(Modifier::BOLD),
+        )),
+        Line::from(""),
+        Line::from(prompt.to_string()),
+    ])
+    .block(Block::default().borders(Borders::ALL))
+    .wrap(Wrap { trim: true });
+    frame.render_widget(paragraph, area);
+}
+
+fn render_compact(frame: &mut Frame<'_>, area: Rect, app: &App) {
+    let mut lines = vec![Line::from(Span::styled(
+        "TREE RING MEMORY",
+        Style::default()
+            .fg(Color::LightYellow)
+            .add_modifier(Modifier::BOLD),
+    ))];
+    lines.extend(ambient_tree_lines(&app.dashboard, app.tick));
+    lines.push(Line::from(format!(
+        "total {} | q quit | / command",
+        app.dashboard.total
+    )));
+    let paragraph = Paragraph::new(lines)
+        .block(Block::default().borders(Borders::ALL))
+        .wrap(Wrap { trim: false });
+    frame.render_widget(paragraph, area);
+}
+
+fn centered_rect(percent_x: u16, percent_y: u16, area: Rect) -> Rect {
+    let popup_layout = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Percentage((100 - percent_y) / 2),
+            Constraint::Percentage(percent_y),
+            Constraint::Percentage((100 - percent_y) / 2),
+        ])
+        .split(area);
+    Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([
+            Constraint::Percentage((100 - percent_x) / 2),
+            Constraint::Percentage(percent_x),
+            Constraint::Percentage((100 - percent_x) / 2),
+        ])
+        .split(popup_layout[1])[1]
+}
+
+fn truncate(value: &str, max: usize) -> String {
+    if value.chars().count() <= max {
+        return value.to_string();
+    }
+    value
+        .chars()
+        .take(max.saturating_sub(3))
+        .collect::<String>()
+        + "..."
+}
+
+#[cfg(test)]
+mod tests {
+    use ratatui::backend::TestBackend;
+    use ratatui::Terminal;
+    use tempfile::tempdir;
+
+    use super::*;
+    use crate::tui::app::App;
+
+    #[test]
+    fn render_buffer_contains_ambient_rings_and_actions() {
+        let dir = tempdir().unwrap();
+        let mut app = App::new(dir.path().join(".tree-ring"), None).unwrap();
+        app.execute_slash_command("/remember Use Rust TUI").unwrap();
+        let backend = TestBackend::new(120, 36);
+        let mut terminal = Terminal::new(backend).unwrap();
+
+        terminal.draw(|frame| render(frame, &app)).unwrap();
+        let output = terminal.backend().to_string();
+
+        assert!(output.contains("TREE RING MEMORY"));
+        assert!(output.contains("Ambient Rings"));
+        assert!(output.contains("Actions"));
+        assert!(output.contains("cambium"));
+    }
+}

--- a/crates/tree-ring-memory-cli/src/tui/rings.rs
+++ b/crates/tree-ring-memory-cli/src/tui/rings.rs
@@ -1,0 +1,155 @@
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::{Line, Span};
+
+use super::model::{DashboardStats, RingStats};
+
+pub fn ring_color(ring: &str, warning_level: f64) -> Color {
+    if warning_level > 0.75 {
+        return Color::LightRed;
+    }
+    match ring {
+        "cambium" => Color::LightYellow,
+        "outer" => Color::LightMagenta,
+        "inner" => Color::Cyan,
+        "heartwood" => Color::Yellow,
+        "scar" => Color::Red,
+        "seed" => Color::LightCyan,
+        _ => Color::Gray,
+    }
+}
+
+pub fn ring_style(stats: &RingStats) -> Style {
+    let mut style = Style::default().fg(ring_color(&stats.ring, stats.warning_level));
+    if stats.pulse_level > 0.55 {
+        style = style.add_modifier(Modifier::BOLD);
+    }
+    if stats.warning_level > 0.0 {
+        style = style.add_modifier(Modifier::UNDERLINED);
+    }
+    style
+}
+
+pub fn ambient_tree_lines(dashboard: &DashboardStats, tick: u64) -> Vec<Line<'static>> {
+    let phase = if tick % 8 < 4 { "*" } else { "+" };
+    let fallback = RingStats::empty("unknown");
+    let heartwood = dashboard.ring("heartwood").unwrap_or(&fallback);
+    let inner = dashboard.ring("inner").unwrap_or(&fallback);
+    let outer = dashboard.ring("outer").unwrap_or(&fallback);
+    let cambium = dashboard.ring("cambium").unwrap_or(&fallback);
+    let scar = dashboard.ring("scar").unwrap_or(&fallback);
+    let seed = dashboard.ring("seed").unwrap_or(&fallback);
+
+    vec![
+        Line::from(Span::styled(
+            format!("        .-=================-.        {phase}"),
+            ring_style(cambium),
+        )),
+        Line::from(Span::styled(
+            format!("     .-'   cambium {:>5}   '-.", cambium.total),
+            ring_style(cambium),
+        )),
+        Line::from(Span::styled(
+            format!("   .'   .--- outer {:>5} ---.   '.", outer.total),
+            ring_style(outer),
+        )),
+        Line::from(Span::styled(
+            format!("  /   .'   .-- inner {:>5} --.   '.  \\", inner.total),
+            ring_style(inner),
+        )),
+        Line::from(vec![
+            Span::styled(" |   /   .'", ring_style(inner)),
+            Span::styled(
+                format!(" heartwood {:>5} ", heartwood.total),
+                ring_style(heartwood),
+            ),
+            Span::styled("'.   \\   |", ring_style(inner)),
+        ]),
+        Line::from(Span::styled(
+            format!(
+                "  \\   '.   scars {:>4} seeds {:>4} .'   /",
+                scar.total, seed.total
+            ),
+            if scar.total > 0 {
+                ring_style(scar)
+            } else {
+                ring_style(seed)
+            },
+        )),
+        Line::from(Span::styled(
+            "   '.   '---.          .---'   .'".to_string(),
+            ring_style(outer),
+        )),
+        Line::from(Span::styled(
+            "     '-.       '------'       .-'".to_string(),
+            ring_style(cambium),
+        )),
+        Line::from(Span::styled(
+            "        '==================='".to_string(),
+            ring_style(cambium),
+        )),
+    ]
+}
+
+pub fn exploded_ring_lines(dashboard: &DashboardStats, selected_ring: usize) -> Vec<Line<'static>> {
+    let mut lines = vec![Line::from(Span::styled(
+        "EXPLODED RINGS".to_string(),
+        Style::default()
+            .fg(Color::White)
+            .add_modifier(Modifier::BOLD),
+    ))];
+
+    for (index, stats) in dashboard.rings.iter().enumerate() {
+        let marker = if index == selected_ring { ">" } else { " " };
+        let bar = ring_bar(stats.total, dashboard.total);
+        let top_types = stats.top_event_types(2).join(", ");
+        lines.push(Line::from(vec![
+            Span::raw(format!("{marker} ")),
+            Span::styled(format!("{:<10}", stats.ring), ring_style(stats)),
+            Span::raw(format!(" {:>4} ", stats.total)),
+            Span::styled(bar, ring_style(stats)),
+            Span::raw(format!(
+                " conf {:.2} sal {:.2} private {}",
+                stats.average_confidence, stats.average_salience, stats.sensitive_count
+            )),
+        ]));
+        if !top_types.is_empty() {
+            lines.push(Line::from(Span::raw(format!("    top: {top_types}"))));
+        }
+    }
+
+    lines
+}
+
+fn ring_bar(count: usize, total: usize) -> String {
+    let width = 16usize;
+    if total == 0 {
+        return ".".repeat(width);
+    }
+    let filled = ((count as f64 / total as f64) * width as f64).round() as usize;
+    "#".repeat(filled.max(1).min(width))
+        + &".".repeat(width.saturating_sub(filled.max(1).min(width)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tree_ring_memory_core::MemoryEvent;
+
+    #[test]
+    fn ambient_lines_include_all_core_ring_labels() {
+        let mut memory = MemoryEvent::new("Durable", "lesson").unwrap();
+        memory.ring = "heartwood".to_string();
+        let dashboard = DashboardStats::from_memories(&[memory], None);
+
+        let joined = ambient_tree_lines(&dashboard, 0)
+            .into_iter()
+            .map(|line| line.to_string())
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        assert!(joined.contains("cambium"));
+        assert!(joined.contains("outer"));
+        assert!(joined.contains("inner"));
+        assert!(joined.contains("heartwood"));
+    }
+}

--- a/crates/tree-ring-memory-cli/src/tui/store_watch.rs
+++ b/crates/tree-ring-memory-cli/src/tui/store_watch.rs
@@ -1,0 +1,52 @@
+use tree_ring_memory_core::MemoryEvent;
+use tree_ring_memory_sqlite::SQLiteMemoryStore;
+
+use super::model::DashboardStats;
+
+#[derive(Debug, Clone)]
+pub struct StoreSnapshot {
+    pub memories: Vec<MemoryEvent>,
+    pub dashboard: DashboardStats,
+}
+
+pub struct StoreWatcher {
+    previous: Option<DashboardStats>,
+}
+
+impl StoreWatcher {
+    pub fn new() -> Self {
+        Self { previous: None }
+    }
+
+    pub fn refresh(&mut self, store: &SQLiteMemoryStore) -> Result<StoreSnapshot, String> {
+        let memories = store.list_all(true).map_err(|err| err.to_string())?;
+        let dashboard = DashboardStats::from_memories(&memories, self.previous.as_ref());
+        self.previous = Some(dashboard.clone());
+        Ok(StoreSnapshot {
+            memories,
+            dashboard,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use tempfile::tempdir;
+    use tree_ring_memory_core::MemoryEvent;
+
+    use super::*;
+
+    #[test]
+    fn store_refresh_derives_current_counts() {
+        let dir = tempdir().unwrap();
+        let mut store = SQLiteMemoryStore::open(dir.path().join("memory.sqlite")).unwrap();
+        let event = MemoryEvent::new("Use store watch", "lesson").unwrap();
+        store.put(&event).unwrap();
+        let mut watcher = StoreWatcher::new();
+
+        let snapshot = watcher.refresh(&store).unwrap();
+
+        assert_eq!(snapshot.dashboard.total, 1);
+        assert_eq!(snapshot.memories.len(), 1);
+    }
+}

--- a/crates/tree-ring-memory-cli/src/tui/stream.rs
+++ b/crates/tree-ring-memory-cli/src/tui/stream.rs
@@ -1,0 +1,117 @@
+use std::fs::File;
+use std::io::{Read, Seek, SeekFrom};
+use std::path::PathBuf;
+
+use serde::Deserialize;
+
+#[derive(Debug, Clone, PartialEq, Deserialize)]
+pub struct LiveEvent {
+    #[serde(default)]
+    pub timestamp: Option<String>,
+    #[serde(default)]
+    pub event: String,
+    #[serde(default)]
+    pub ring: Option<String>,
+    #[serde(default)]
+    pub project: Option<String>,
+    #[serde(default)]
+    pub agent_profile: Option<String>,
+    #[serde(default)]
+    pub count_delta: Option<i64>,
+    #[serde(default)]
+    pub label: Option<String>,
+}
+
+impl LiveEvent {
+    pub fn safe_label(&self) -> String {
+        self.label
+            .as_deref()
+            .unwrap_or(&self.event)
+            .chars()
+            .filter(|character| !character.is_control())
+            .take(96)
+            .collect()
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct EventStreamReader {
+    path: PathBuf,
+    offset: u64,
+}
+
+impl EventStreamReader {
+    pub fn new(path: PathBuf) -> Self {
+        Self { path, offset: 0 }
+    }
+
+    pub fn read_new_events(&mut self) -> Result<Vec<LiveEvent>, String> {
+        let Ok(mut file) = File::open(&self.path) else {
+            return Ok(Vec::new());
+        };
+        let file_len = file.metadata().map_err(|err| err.to_string())?.len();
+        if file_len < self.offset {
+            self.offset = 0;
+        }
+        file.seek(SeekFrom::Start(self.offset))
+            .map_err(|err| err.to_string())?;
+        let mut appended = String::new();
+        file.read_to_string(&mut appended)
+            .map_err(|err| err.to_string())?;
+        self.offset = file.stream_position().map_err(|err| err.to_string())?;
+
+        let mut events = Vec::new();
+        for line in appended.lines() {
+            if line.trim().is_empty() {
+                continue;
+            }
+            if let Ok(event) = serde_json::from_str::<LiveEvent>(line) {
+                events.push(event);
+            }
+        }
+        Ok(events)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Write;
+
+    use super::*;
+    use tempfile::NamedTempFile;
+
+    #[test]
+    fn reads_appended_events_incrementally() {
+        let mut file = NamedTempFile::new().unwrap();
+        writeln!(
+            file,
+            r#"{{"event":"remembered","ring":"cambium","label":"Stored preference"}}"#
+        )
+        .unwrap();
+        let mut reader = EventStreamReader::new(file.path().to_path_buf());
+
+        let first = reader.read_new_events().unwrap();
+        let second = reader.read_new_events().unwrap();
+
+        assert_eq!(first.len(), 1);
+        assert_eq!(first[0].ring.as_deref(), Some("cambium"));
+        assert!(second.is_empty());
+    }
+
+    #[test]
+    fn ignores_malformed_lines_without_leaking_payload() {
+        let mut file = NamedTempFile::new().unwrap();
+        writeln!(file, "not-json").unwrap();
+        writeln!(
+            file,
+            r#"{{"event":"policy_blocked","label":"secret blocked"}}"#
+        )
+        .unwrap();
+        let mut reader = EventStreamReader::new(file.path().to_path_buf());
+
+        let events = reader.read_new_events().unwrap();
+
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].safe_label(), "secret blocked");
+    }
+}

--- a/docs/architecture/rust-core-status.md
+++ b/docs/architecture/rust-core-status.md
@@ -1,8 +1,9 @@
 # Rust Core Status
 
 Tree Ring Memory has moved from a Python-owned reference implementation toward
-a Rust-first core with Python compatibility. This page tracks the v0.2 Rust core
-and v0.3 native Python binding work.
+a Rust-first core with Python compatibility. This page tracks the v0.2 Rust
+core, v0.3 native Python binding work, and the Rust-native Ratatui terminal
+console now being added to the CLI.
 
 ## Current Status
 
@@ -26,6 +27,10 @@ and v0.3 native Python binding work.
   contracts, including details, source metadata, agent profile, scores,
   retention, expiry, links, review metadata, supersession, recall filters,
   superseded-memory inclusion, and ranking explanations.
+- The Rust CLI now includes `tree-ring tui`, a Ratatui operator console with an
+  always-visible animated ASCII tree-ring view, SQLite store-watch refresh,
+  optional JSONL event-stream pulses, search/detail panes, and confirmation
+  gates for destructive or authority-changing actions.
 
 ## Build Commands
 
@@ -33,6 +38,7 @@ and v0.3 native Python binding work.
 cargo test
 python3 -m pytest
 cargo run -p tree-ring-memory-cli -- --help
+cargo run -p tree-ring-memory-cli -- tui --help
 python3 scripts/rust_performance_smoke.py --count 1000
 cargo build -p tree-ring-memory-python --features extension-module
 python3 scripts/native_binding_smoke.py --install-maturin
@@ -83,6 +89,9 @@ Backend controls:
   SQLite/FTS storage, transactional row/FTS consistency, redaction, and basic
   concurrent writes. Rust binding tests cover native JSON remember/recall
   round-trip and forget validation.
+- Rust CLI tests cover the scriptable init/remember/recall/forget commands and
+  the Ratatui TUI model, stream reader, slash-command parser, store-watch
+  refresh, confirmation-gated actions, CLI parsing, and render-buffer smoke.
 - Python tests cover the existing reference backend, Rust CLI database
   compatibility, the opt-in `RustCliTreeRingMemory` adapter, default facade
   native selection, full native wrapper argument marshalling, and clean

--- a/docs/superpowers/plans/2026-07-05-tree-ring-memory-ratatui-tui-implementation-plan.md
+++ b/docs/superpowers/plans/2026-07-05-tree-ring-memory-ratatui-tui-implementation-plan.md
@@ -1,0 +1,140 @@
+# Tree Ring Memory Ratatui TUI Implementation Plan
+
+## Goal
+
+Implement the approved Rust-native Ratatui terminal interface behind `tree-ring tui`. The first implementation must be useful, testable, and faithful to the tree-ring memory lifecycle: ambient animated ASCII rings, real-time store refresh, event-stream pulses, search/detail views, and guided operator actions.
+
+## Constraints
+
+- Implement in Rust, inside the CLI crate/workspace.
+- Do not implement the TUI in Python.
+- Keep existing scriptable CLI commands working.
+- Keep memory framework-agnostic.
+- Do not make the TUI a raw transcript/log browser.
+- Keep dangerous actions confirmation-gated.
+
+## Tasks
+
+### 1. Dependencies And CLI Entry
+
+- Add Ratatui with the default crossterm backend to the CLI crate.
+- Add a `tree-ring tui` subcommand.
+- Add optional arguments:
+  - `--event-stream <path>` for local JSONL event stream input.
+  - `--tick-ms <number>` for animation/update cadence.
+- Keep `--json` ignored or rejected for `tui`; the TUI is interactive.
+
+### 2. TUI Module Skeleton
+
+Create:
+
+```text
+crates/tree-ring-memory-cli/src/tui/
+├── mod.rs
+├── app.rs
+├── actions.rs
+├── event.rs
+├── input.rs
+├── model.rs
+├── render.rs
+├── rings.rs
+├── store_watch.rs
+└── stream.rs
+```
+
+### 3. State Model
+
+- Derive ring stats from the Rust SQLite store.
+- Track ring counts, event type counts, sensitive counts, superseded counts, average salience/confidence, newest/oldest timestamps, pulse level, and warning level.
+- Track search query, recall results, selected result, selected ring, mode, pending action, and status message.
+
+### 4. Store Watch
+
+- Implement polling-based store refresh first.
+- Refresh stats and current recall results on each configured tick.
+- Detect ring count deltas and feed pulse events.
+- Keep file watching replaceable later through a `StoreWatcher` boundary.
+
+### 5. Event Stream
+
+- Read optional JSONL events from `--event-stream`.
+- Process appended lines incrementally.
+- Treat events as untrusted display signals.
+- Supported event payload fields: timestamp, event, ring, project, agent_profile, count_delta, label.
+- Event-stream signals update pulse state and the status/event pane without bypassing persisted store truth.
+
+### 6. Rendering
+
+- Default mode:
+  - Ambient ASCII ring core.
+  - Ring stats/status HUD.
+  - Search/results pane.
+  - Selected memory detail.
+  - Action rail/help footer.
+- Exploded mode:
+  - Separated rings with data bubbles.
+  - Ring-specific counts and notes.
+- Use retro color mapping with 16-color fallback.
+- Keep small-terminal fallback readable.
+
+### 7. Input And Commands
+
+- Keyboard navigation: arrows/j/k, Tab, Enter, Escape, q.
+- Slash command palette:
+  - `/rings`
+  - `/search`
+  - `/remember`
+  - `/forget`
+  - `/redact`
+  - `/promote`
+  - `/scar`
+  - `/seed`
+  - `/supersede`
+  - `/consolidate`
+  - `/export`
+  - `/sync`
+  - `/stream`
+  - `/watch`
+- Start with guided action panels for remember, forget, redact, promote, scar, seed, supersede.
+- Show not-yet-implemented but non-crashing messages for consolidate/export/sync if the underlying Rust APIs are not ready.
+
+### 8. Safety Gates
+
+- Require explicit confirmation for forget, redact, promote, scar, seed, supersede, export sensitive, and consolidate.
+- Run sensitivity checks before remember/edit actions.
+- Never render sensitive details unless the include-sensitive toggle is enabled.
+- Do not render raw event-stream payloads; render policy-safe labels.
+
+### 9. Tests
+
+- Ring stats derive correct counts.
+- Store refresh updates stats.
+- Event stream updates pulse state.
+- Slash commands switch modes.
+- Dangerous action commands create pending confirmation instead of executing directly.
+- Render snapshots or buffer assertions include the ambient ring, ring labels, and action rail.
+- CLI parse test covers `tree-ring tui`.
+
+### 10. Verification
+
+Run:
+
+```bash
+cargo fmt
+cargo test
+python3 -m pytest
+cargo build -p tree-ring-memory-python --features extension-module
+python3 scripts/native_binding_smoke.py --install-maturin
+python3 scripts/rust_performance_smoke.py --count 10000
+```
+
+## Definition Of Done
+
+- `tree-ring tui` launches an interactive Ratatui application.
+- Ambient ASCII tree rings are always visible.
+- Ring lighting responds to store-watch and event-stream changes.
+- `/rings` opens an exploded-ring view.
+- Search/detail/filters are usable.
+- Full operator actions have safe guided flows or clear non-destructive placeholders where backend APIs are intentionally deferred.
+- Rust owns the TUI behavior.
+- Tests and smoke checks pass.


### PR DESCRIPTION
Summary:
- Add tree-ring tui as a Rust-native Ratatui operator console with always-visible animated ASCII tree rings.
- Add store-watch refresh, optional JSONL event-stream pulses, search/detail panes, slash commands, and confirmation-gated actions.
- Document the terminal console, safe event-stream contract, and Rust status.

Verification:
- cargo fmt: passed.
- cargo test: passed.
- python3 -m pytest: 80 passed.
- cargo run -q -p tree-ring-memory-cli -- --help: passed.
- cargo run -q -p tree-ring-memory-cli -- tui --help: passed.
- cargo run -q -p tree-ring-memory-cli -- --json tui: rejected safely before terminal setup.
- cargo run -q -p tree-ring-memory-cli -- --root /private/tmp/trm-tui-smoke init/remember/recall: passed.
- cargo build -p tree-ring-memory-python --features extension-module: passed.
- python3 scripts/native_binding_smoke.py --install-maturin: passed; native version 0.3.0.
- python3 scripts/rust_performance_smoke.py --count 10000: passed; 10,000 inserts, 2,189.6 inserts/sec, recall avg 8.143 ms, max 15.649 ms.

Notes:
- Python remains compatibility/wrapper surface; the TUI is Rust-owned.
- .vscode/ remains untracked and was not included.