### PR TITLE
Add Rust JSONL import/export

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1759,7 +1759,7 @@ checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "tree-ring-memory-cli"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "clap",
  "ratatui",
@@ -1772,7 +1772,7 @@ dependencies = [
 
 [[package]]
 name = "tree-ring-memory-core"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "chrono",
  "once_cell",
@@ -1785,7 +1785,7 @@ dependencies = [
 
 [[package]]
 name = "tree-ring-memory-python"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "pyo3",
  "pyo3-build-config",
@@ -1798,7 +1798,7 @@ dependencies = [
 
 [[package]]
 name = "tree-ring-memory-sqlite"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "rusqlite",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 license = "MIT"
 authors = ["TerminallyLazy"]

--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ Tree Ring Memory is in protocol-preview status.
 - v0.1 provides a local Python reference library with SQLite storage and no required cloud services.
 - v0.2 moved durable behavior into a Rust core while preserving Python compatibility.
 - v0.3 makes the public Python facade Rust-first when the optional PyO3 native module is installed.
-- The current Rust branch adds a Ratatui operator console behind `tree-ring tui`.
+- v0.4 adds Rust-owned JSONL import/export with privacy-preserving defaults across the CLI, native Python backend, and Python reference backend.
+- The Rust CLI also includes a Ratatui operator console behind `tree-ring tui`.
 
 The Rust workspace currently includes:
 
@@ -62,6 +63,18 @@ maturin develop
 The native binding package is extension-only. It does not package or own the
 public `tree_ring_memory` Python package; install the main package separately in
 the same environment.
+
+The native and reference Python backends expose portable JSONL import/export:
+
+```python
+jsonl = memory.export_jsonl()
+preview = memory.import_jsonl(jsonl, dry_run=True)
+report = memory.import_jsonl(jsonl)
+```
+
+Exports exclude sensitive and superseded memories by default. Pass
+`include_sensitive=True` or `include_superseded=True` only when the caller
+explicitly needs those rows.
 
 Backend selection:
 
@@ -110,9 +123,19 @@ tree-ring init
 tree-ring remember "Use protocol-first design." --event-type decision --tag architecture
 tree-ring recall "protocol design"
 tree-ring forget mem_example --mode delete --reason "example cleanup"
+tree-ring export --output memories.jsonl
+tree-ring import memories.jsonl --dry-run
+tree-ring import memories.jsonl
 ```
 
 The CLI stores memory in `.tree-ring/` by default.
+
+`tree-ring export` writes newline-delimited JSON. The first line is a
+`tree_ring_memory_export` header with schema and plugin version metadata; each
+remaining line is a `memory_event` envelope. The command excludes sensitive and
+superseded memories unless `--include-sensitive` or `--include-superseded` is
+set. Import validates all events, skips duplicate ids by default, and replaces
+existing ids only with `--replace-existing`.
 
 ## Terminal Console Preview
 
@@ -156,6 +179,8 @@ Event stream lines are local JSONL objects. They are display signals only:
 cargo test
 python3 -m pytest
 cargo run -p tree-ring-memory-cli -- --help
+cargo run -p tree-ring-memory-cli -- export --help
+cargo run -p tree-ring-memory-cli -- import --help
 python3 scripts/rust_performance_smoke.py --count 1000
 cargo build -p tree-ring-memory-python --features extension-module
 python3 scripts/native_binding_smoke.py --install-maturin
@@ -178,6 +203,8 @@ latency of 250 ms for the synthetic workload.
 - `docs/superpowers/plans/2026-07-05-tree-ring-memory-rust-python-bindings-v0-3-implementation-plan.md`
 - `docs/superpowers/specs/2026-07-05-tree-ring-memory-ratatui-tui-design.md`
 - `docs/superpowers/plans/2026-07-05-tree-ring-memory-ratatui-tui-implementation-plan.md`
+- `docs/superpowers/specs/2026-07-05-tree-ring-memory-rust-import-export-v0-4-design.md`
+- `docs/superpowers/plans/2026-07-05-tree-ring-memory-rust-import-export-v0-4-implementation-plan.md`
 
 ## Agent Workflow Integration
 

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "tree-ring-memory-native"
-version = "0.3.0"
+version = "0.4.0"
 description = "Native Rust bindings for Tree Ring Memory."
 requires-python = ">=3.11"
 license = { file = "../../LICENSE" }

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -178,6 +178,40 @@ impl PyTreeRingMemoryNative {
             ))),
         }
     }
+
+    #[pyo3(signature = (include_sensitive=false, include_superseded=false))]
+    pub fn export_jsonl(
+        &self,
+        include_sensitive: bool,
+        include_superseded: bool,
+    ) -> PyResult<String> {
+        let (jsonl, _report) = self
+            .store
+            .export_jsonl(include_sensitive, include_superseded)
+            .map_err(to_py_runtime_error)?;
+        Ok(jsonl)
+    }
+
+    #[pyo3(signature = (data, dry_run=false, replace_existing=false))]
+    pub fn import_jsonl(
+        &mut self,
+        data: &str,
+        dry_run: bool,
+        replace_existing: bool,
+    ) -> PyResult<String> {
+        let report = self
+            .store
+            .import_jsonl(data, dry_run, replace_existing)
+            .map_err(to_py_runtime_error)?;
+        serde_json::to_string(&serde_json::json!({
+            "valid_count": report.valid_count,
+            "inserted_count": report.inserted_count,
+            "replaced_count": report.replaced_count,
+            "skipped_duplicate_count": report.skipped_duplicate_count,
+            "dry_run": report.dry_run,
+        }))
+        .map_err(to_py_runtime_error)
+    }
 }
 
 impl PyTreeRingMemoryNative {
@@ -564,5 +598,53 @@ mod tests {
         assert_eq!(stored.sensitivity, "health");
         assert_eq!(hidden, "[]");
         assert!(visible.contains(&stored.id));
+    }
+
+    #[test]
+    fn native_binding_exports_and_imports_jsonl() {
+        pyo3::prepare_freethreaded_python();
+        let source_dir = tempdir().unwrap();
+        let target_dir = tempdir().unwrap();
+        let mut source = PyTreeRingMemoryNative::open(
+            source_dir.path().join(".tree-ring").display().to_string(),
+        )
+        .unwrap();
+        let mut target = PyTreeRingMemoryNative::open(
+            target_dir.path().join(".tree-ring").display().to_string(),
+        )
+        .unwrap();
+        let event_json = source
+            .remember_event_json(
+                &serde_json::json!({
+                    "summary": "Native JSONL import export preserves memory.",
+                    "event_type": "lesson",
+                    "project": "bindings"
+                })
+                .to_string(),
+            )
+            .unwrap();
+        let event: MemoryEvent = serde_json::from_str(&event_json).unwrap();
+
+        let jsonl = source.export_jsonl(false, false).unwrap();
+        let dry_run_report: serde_json::Value =
+            serde_json::from_str(&target.import_jsonl(&jsonl, true, false).unwrap()).unwrap();
+        let import_report: serde_json::Value =
+            serde_json::from_str(&target.import_jsonl(&jsonl, false, false).unwrap()).unwrap();
+
+        assert!(jsonl.contains("tree_ring_memory_export"));
+        assert!(jsonl.contains(&event.id));
+        assert_eq!(dry_run_report["valid_count"], 1);
+        assert_eq!(dry_run_report["inserted_count"], 0);
+        assert_eq!(dry_run_report["dry_run"], true);
+        assert_eq!(import_report["inserted_count"], 1);
+        assert!(target
+            .recall_json(
+                "JSONL preserves memory".to_string(),
+                Some("bindings".to_string()),
+                8,
+                false
+            )
+            .unwrap()
+            .contains(&event.id));
     }
 }

--- a/crates/tree-ring-memory-cli/src/main.rs
+++ b/crates/tree-ring-memory-cli/src/main.rs
@@ -1,8 +1,10 @@
 use clap::{Parser, Subcommand};
 use serde_json::json;
+use std::fs;
 use std::path::PathBuf;
 use tree_ring_memory_core::sensitivity::SensitivityGuard;
 use tree_ring_memory_core::MemoryEvent;
+use tree_ring_memory_core::{decode_jsonl, normalize_import_events};
 use tree_ring_memory_sqlite::{MemoryRetriever, SQLiteMemoryStore};
 
 mod tui;
@@ -54,6 +56,23 @@ enum Command {
         #[arg(long)]
         reason: String,
     },
+    #[command(about = "export memories as portable JSONL")]
+    Export {
+        #[arg(long, help = "write JSONL export to a file instead of stdout")]
+        output: Option<PathBuf>,
+        #[arg(long, help = "include sensitive memories in the export")]
+        include_sensitive: bool,
+        #[arg(long, help = "include superseded memories in the export")]
+        include_superseded: bool,
+    },
+    #[command(about = "import memories from portable JSONL")]
+    Import {
+        path: PathBuf,
+        #[arg(long, help = "validate the import without writing memories")]
+        dry_run: bool,
+        #[arg(long, help = "replace existing memories with matching ids")]
+        replace_existing: bool,
+    },
     #[command(about = "open the Rust-native Tree Ring Memory terminal console")]
     Tui {
         #[arg(long, help = "optional JSONL event stream to light rings in real time")]
@@ -95,6 +114,37 @@ fn run(cli: Cli) -> Result<(), String> {
             return Err("--json is not supported with the interactive TUI".to_string());
         }
         return tui::run(cli.root, event_stream, tick_ms);
+    }
+
+    if let Command::Import {
+        path,
+        dry_run: true,
+        replace_existing: _,
+    } = cli.command
+    {
+        let input = fs::read_to_string(&path).map_err(|err| err.to_string())?;
+        let decoded = decode_jsonl(&input).map_err(|err| err.to_string())?;
+        let events = normalize_import_events(decoded.events).map_err(|err| err.to_string())?;
+        if cli.json {
+            println!(
+                "{}",
+                json!({
+                    "ok": true,
+                    "path": path,
+                    "valid_count": events.len(),
+                    "inserted_count": 0,
+                    "replaced_count": 0,
+                    "skipped_duplicate_count": 0,
+                    "dry_run": true,
+                })
+            );
+        } else {
+            println!(
+                "Tree Ring Memory import complete: valid={} inserted=0 replaced=0 skipped_duplicates=0 dry_run=true",
+                events.len()
+            );
+        }
+        return Ok(());
     }
 
     let mut store = SQLiteMemoryStore::open(&db_path).map_err(|err| err.to_string())?;
@@ -212,6 +262,76 @@ fn run(cli: Cli) -> Result<(), String> {
                 println!("{}", json!({"ok": true, "memory_id": memory_id}));
             } else {
                 println!("Tree Ring Memory forget complete: {memory_id}");
+            }
+        }
+        Command::Export {
+            output,
+            include_sensitive,
+            include_superseded,
+        } => {
+            let (jsonl, report) = store
+                .export_jsonl(include_sensitive, include_superseded)
+                .map_err(|err| err.to_string())?;
+            if let Some(output) = output {
+                if let Some(parent) = output.parent() {
+                    if !parent.as_os_str().is_empty() {
+                        fs::create_dir_all(parent).map_err(|err| err.to_string())?;
+                    }
+                }
+                fs::write(&output, jsonl).map_err(|err| err.to_string())?;
+                if cli.json {
+                    println!(
+                        "{}",
+                        json!({
+                            "ok": true,
+                            "path": output,
+                            "memory_count": report.memory_count,
+                            "sensitive_included": report.sensitive_included,
+                            "superseded_included": report.superseded_included,
+                        })
+                    );
+                } else {
+                    println!(
+                        "Tree Ring Memory export complete: {} memories -> {}",
+                        report.memory_count,
+                        output.display()
+                    );
+                }
+            } else {
+                print!("{jsonl}");
+            }
+        }
+        Command::Import {
+            path,
+            dry_run,
+            replace_existing,
+        } => {
+            let input = fs::read_to_string(&path).map_err(|err| err.to_string())?;
+            let report = store
+                .import_jsonl(&input, dry_run, replace_existing)
+                .map_err(|err| err.to_string())?;
+            if cli.json {
+                println!(
+                    "{}",
+                    json!({
+                        "ok": true,
+                        "path": path,
+                        "valid_count": report.valid_count,
+                        "inserted_count": report.inserted_count,
+                        "replaced_count": report.replaced_count,
+                        "skipped_duplicate_count": report.skipped_duplicate_count,
+                        "dry_run": report.dry_run,
+                    })
+                );
+            } else {
+                println!(
+                    "Tree Ring Memory import complete: valid={} inserted={} replaced={} skipped_duplicates={} dry_run={}",
+                    report.valid_count,
+                    report.inserted_count,
+                    report.replaced_count,
+                    report.skipped_duplicate_count,
+                    report.dry_run
+                );
             }
         }
         Command::Tui { .. } => unreachable!("tui returns before opening the scriptable store"),

--- a/crates/tree-ring-memory-core/src/import_export.rs
+++ b/crates/tree-ring-memory-core/src/import_export.rs
@@ -1,0 +1,219 @@
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::models::{now_iso, MemoryEvent, TreeRingError, TreeRingResult};
+use crate::sensitivity::SensitivityGuard;
+
+pub const EXPORT_RECORD_TYPE: &str = "tree_ring_memory_export";
+pub const MEMORY_EVENT_RECORD_TYPE: &str = "memory_event";
+pub const EXPORT_SCHEMA_VERSION: u32 = 1;
+pub const EXPORT_PLUGIN_VERSION: &str = env!("CARGO_PKG_VERSION");
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ExportHeader {
+    #[serde(rename = "type")]
+    pub record_type: String,
+    pub schema_version: u32,
+    pub plugin_version: String,
+    pub created_at: String,
+    pub memory_count: usize,
+    pub sensitive_included: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct MemoryEventEnvelope {
+    #[serde(rename = "type")]
+    pub record_type: String,
+    pub memory: MemoryEvent,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct DecodedJsonl {
+    pub header: Option<ExportHeader>,
+    pub events: Vec<MemoryEvent>,
+}
+
+pub fn encode_jsonl(events: &[MemoryEvent], sensitive_included: bool) -> TreeRingResult<String> {
+    for event in events {
+        event.validate()?;
+    }
+    let header = ExportHeader {
+        record_type: EXPORT_RECORD_TYPE.to_string(),
+        schema_version: EXPORT_SCHEMA_VERSION,
+        plugin_version: EXPORT_PLUGIN_VERSION.to_string(),
+        created_at: now_iso(),
+        memory_count: events.len(),
+        sensitive_included,
+    };
+
+    let mut output = String::new();
+    output.push_str(&serde_json::to_string(&header)?);
+    output.push('\n');
+    for event in events {
+        let envelope = MemoryEventEnvelope {
+            record_type: MEMORY_EVENT_RECORD_TYPE.to_string(),
+            memory: event.clone(),
+        };
+        output.push_str(&serde_json::to_string(&envelope)?);
+        output.push('\n');
+    }
+    Ok(output)
+}
+
+pub fn decode_jsonl(input: &str) -> TreeRingResult<DecodedJsonl> {
+    let mut header = None;
+    let mut events = Vec::new();
+
+    for (index, line) in input.lines().enumerate() {
+        let line_number = index + 1;
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        let value: Value = serde_json::from_str(trimmed).map_err(|err| {
+            TreeRingError::Validation(format!("line {line_number}: invalid json: {err}"))
+        })?;
+        match value.get("type").and_then(Value::as_str) {
+            Some(EXPORT_RECORD_TYPE) => {
+                let parsed: ExportHeader = serde_json::from_value(value).map_err(|err| {
+                    TreeRingError::Validation(format!(
+                        "line {line_number}: invalid export header: {err}"
+                    ))
+                })?;
+                if parsed.schema_version != EXPORT_SCHEMA_VERSION {
+                    return Err(TreeRingError::Validation(format!(
+                        "line {line_number}: unsupported export schema version {}",
+                        parsed.schema_version
+                    )));
+                }
+                header = Some(parsed);
+            }
+            Some(MEMORY_EVENT_RECORD_TYPE) => {
+                let parsed: MemoryEventEnvelope = serde_json::from_value(value).map_err(|err| {
+                    TreeRingError::Validation(format!(
+                        "line {line_number}: invalid memory envelope: {err}"
+                    ))
+                })?;
+                parsed.memory.validate().map_err(|err| {
+                    TreeRingError::Validation(format!("line {line_number}: {err}"))
+                })?;
+                events.push(parsed.memory);
+            }
+            _ => {
+                let parsed: MemoryEvent = serde_json::from_value(value).map_err(|err| {
+                    TreeRingError::Validation(format!(
+                        "line {line_number}: invalid memory event: {err}"
+                    ))
+                })?;
+                parsed.validate().map_err(|err| {
+                    TreeRingError::Validation(format!("line {line_number}: {err}"))
+                })?;
+                events.push(parsed);
+            }
+        }
+    }
+
+    Ok(DecodedJsonl { header, events })
+}
+
+pub fn normalize_import_events(events: Vec<MemoryEvent>) -> TreeRingResult<Vec<MemoryEvent>> {
+    events.into_iter().map(normalize_import_event).collect()
+}
+
+pub fn normalize_import_event(mut event: MemoryEvent) -> TreeRingResult<MemoryEvent> {
+    let detected = SensitivityGuard::default().detect_memory_event_sensitivity(&event)?;
+    if event.sensitivity == "normal" && detected != "normal" {
+        event.sensitivity = detected;
+    }
+    event.validate()?;
+    Ok(event)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn encodes_header_and_event_envelopes() {
+        let event = MemoryEvent::new("Export this memory.", "lesson").unwrap();
+
+        let jsonl = encode_jsonl(&[event.clone()], false).unwrap();
+        let lines: Vec<_> = jsonl.lines().collect();
+
+        assert_eq!(lines.len(), 2);
+        assert!(lines[0].contains(EXPORT_RECORD_TYPE));
+        assert!(lines[0].contains("\"plugin_version\""));
+        assert!(lines[1].contains(MEMORY_EVENT_RECORD_TYPE));
+        assert!(lines[1].contains(&event.id));
+    }
+
+    #[test]
+    fn decodes_export_envelope_jsonl() {
+        let event = MemoryEvent::new("Import this memory.", "lesson").unwrap();
+        let jsonl = encode_jsonl(&[event.clone()], false).unwrap();
+
+        let decoded = decode_jsonl(&jsonl).unwrap();
+
+        assert_eq!(decoded.header.unwrap().memory_count, 1);
+        assert_eq!(decoded.events, vec![event]);
+    }
+
+    #[test]
+    fn decodes_raw_memory_event_lines_for_compatibility() {
+        let event = MemoryEvent::new("Raw event import.", "lesson").unwrap();
+        let raw = serde_json::to_string(&event).unwrap();
+
+        let decoded = decode_jsonl(&raw).unwrap();
+
+        assert_eq!(decoded.events, vec![event]);
+    }
+
+    #[test]
+    fn ignores_blank_lines() {
+        let decoded = decode_jsonl("\n\n  \n").unwrap();
+
+        assert!(decoded.events.is_empty());
+        assert!(decoded.header.is_none());
+    }
+
+    #[test]
+    fn returns_line_number_for_invalid_json() {
+        let err = decode_jsonl("\nnot-json").unwrap_err().to_string();
+
+        assert!(err.contains("line 2"));
+        assert!(err.contains("invalid json"));
+    }
+
+    #[test]
+    fn returns_line_number_for_invalid_memory() {
+        let err = decode_jsonl(r#"{"type":"memory_event","memory":{"summary":""}}"#)
+            .unwrap_err()
+            .to_string();
+
+        assert!(err.contains("line 1"));
+    }
+
+    #[test]
+    fn normalize_import_event_upgrades_misclassified_sensitive_memory() {
+        let mut event =
+            MemoryEvent::new("Private diagnosis should not be normal.", "lesson").unwrap();
+        event.sensitivity = "normal".to_string();
+
+        let normalized = normalize_import_event(event).unwrap();
+
+        assert_eq!(normalized.sensitivity, "health");
+    }
+
+    #[test]
+    fn normalize_import_event_blocks_secrets() {
+        let event = MemoryEvent::new(
+            "Imported key sk-proj-abcdefghijklmnopqrstuvwxyz1234567890 must fail.",
+            "lesson",
+        )
+        .unwrap();
+
+        let err = normalize_import_event(event).unwrap_err().to_string();
+
+        assert!(err.contains("blocked"));
+    }
+}

--- a/crates/tree-ring-memory-core/src/lib.rs
+++ b/crates/tree-ring-memory-core/src/lib.rs
@@ -1,7 +1,13 @@
+pub mod import_export;
 pub mod models;
 pub mod recall;
 pub mod sensitivity;
 
+pub use import_export::{
+    decode_jsonl, encode_jsonl, normalize_import_event, normalize_import_events, DecodedJsonl,
+    ExportHeader, MemoryEventEnvelope, EXPORT_PLUGIN_VERSION, EXPORT_RECORD_TYPE,
+    EXPORT_SCHEMA_VERSION, MEMORY_EVENT_RECORD_TYPE,
+};
 pub use models::{
     now_iso, MemoryEvent, MemoryLink, MemoryReview, MemorySource, TreeRingError, TreeRingResult,
 };

--- a/crates/tree-ring-memory-sqlite/src/lib.rs
+++ b/crates/tree-ring-memory-sqlite/src/lib.rs
@@ -404,20 +404,24 @@ impl SQLiteMemoryStore {
             return Ok(report);
         }
 
+        let mut imported_events = Vec::new();
         for event in events {
             if self.get(&event.id)?.is_some() {
                 if replace_existing {
                     self.put(&event)?;
-                    self.apply_supersedes(&event)?;
+                    imported_events.push(event);
                     report.replaced_count += 1;
                 } else {
                     report.skipped_duplicate_count += 1;
                 }
             } else {
                 self.put(&event)?;
-                self.apply_supersedes(&event)?;
+                imported_events.push(event);
                 report.inserted_count += 1;
             }
+        }
+        for event in imported_events {
+            self.apply_supersedes(&event)?;
         }
         Ok(report)
     }
@@ -1018,6 +1022,33 @@ mod tests {
             Some(new.id.clone())
         );
         let active_ids: Vec<_> = target
+            .list_all(false)
+            .unwrap()
+            .into_iter()
+            .map(|event| event.id)
+            .collect();
+        assert_eq!(active_ids, vec![new.id]);
+    }
+
+    #[test]
+    fn import_jsonl_applies_supersedes_after_all_imported_rows_are_written() {
+        let dir = tempdir().unwrap();
+        let mut store = SQLiteMemoryStore::open(dir.path().join("memory.sqlite")).unwrap();
+        let old = MemoryEvent::new("Old decision imported after replacement.", "decision").unwrap();
+        let mut new = MemoryEvent::new("New decision imported before old.", "decision").unwrap();
+        new.supersedes = vec![old.id.clone()];
+        let out_of_order_jsonl = encode_jsonl(&[new.clone(), old.clone()], false).unwrap();
+
+        let report = store
+            .import_jsonl(&out_of_order_jsonl, false, false)
+            .unwrap();
+
+        assert_eq!(report.inserted_count, 2);
+        assert_eq!(
+            store.get(&old.id).unwrap().unwrap().superseded_by,
+            Some(new.id.clone())
+        );
+        let active_ids: Vec<_> = store
             .list_all(false)
             .unwrap()
             .into_iter()

--- a/crates/tree-ring-memory-sqlite/src/lib.rs
+++ b/crates/tree-ring-memory-sqlite/src/lib.rs
@@ -8,6 +8,7 @@ use std::time::Duration;
 
 use tree_ring_memory_core::models::{sqlite_error, MemoryEvent, TreeRingError, TreeRingResult};
 use tree_ring_memory_core::recall::{search_queries, RecallScorer};
+use tree_ring_memory_core::{decode_jsonl, encode_jsonl, normalize_import_events};
 
 const WRITE_RETRY_ATTEMPTS: usize = 8;
 const WRITE_RETRY_INITIAL_DELAY_MS: u64 = 5;
@@ -22,6 +23,22 @@ pub struct RecallResult {
 
 pub struct SQLiteMemoryStore {
     connection: Connection,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ExportReport {
+    pub memory_count: usize,
+    pub sensitive_included: bool,
+    pub superseded_included: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ImportReport {
+    pub valid_count: usize,
+    pub inserted_count: usize,
+    pub replaced_count: usize,
+    pub skipped_duplicate_count: usize,
+    pub dry_run: bool,
 }
 
 impl SQLiteMemoryStore {
@@ -347,6 +364,69 @@ impl SQLiteMemoryStore {
         };
         event.redact();
         self.put(&event)
+    }
+
+    pub fn export_jsonl(
+        &self,
+        include_sensitive: bool,
+        include_superseded: bool,
+    ) -> TreeRingResult<(String, ExportReport)> {
+        let events: Vec<_> = self
+            .list_all(include_superseded)?
+            .into_iter()
+            .filter(|event| include_sensitive || event.sensitivity == "normal")
+            .collect();
+        let jsonl = encode_jsonl(&events, include_sensitive)?;
+        let report = ExportReport {
+            memory_count: events.len(),
+            sensitive_included: include_sensitive,
+            superseded_included: include_superseded,
+        };
+        Ok((jsonl, report))
+    }
+
+    pub fn import_jsonl(
+        &mut self,
+        input: &str,
+        dry_run: bool,
+        replace_existing: bool,
+    ) -> TreeRingResult<ImportReport> {
+        let decoded = decode_jsonl(input)?;
+        let events = normalize_import_events(decoded.events)?;
+        let mut report = ImportReport {
+            valid_count: events.len(),
+            inserted_count: 0,
+            replaced_count: 0,
+            skipped_duplicate_count: 0,
+            dry_run,
+        };
+        if dry_run {
+            return Ok(report);
+        }
+
+        for event in events {
+            if self.get(&event.id)?.is_some() {
+                if replace_existing {
+                    self.put(&event)?;
+                    self.apply_supersedes(&event)?;
+                    report.replaced_count += 1;
+                } else {
+                    report.skipped_duplicate_count += 1;
+                }
+            } else {
+                self.put(&event)?;
+                self.apply_supersedes(&event)?;
+                report.inserted_count += 1;
+            }
+        }
+        Ok(report)
+    }
+
+    fn apply_supersedes(&mut self, event: &MemoryEvent) -> TreeRingResult<()> {
+        for old_id in &event.supersedes {
+            self.supersede(old_id, &event.id)?;
+        }
+        Ok(())
     }
 }
 
@@ -814,6 +894,136 @@ mod tests {
             .search_text("sk-proj-abcdefghijklmnopqrstuvwxyz1234567890", true)
             .unwrap()
             .is_empty());
+    }
+
+    #[test]
+    fn export_jsonl_excludes_sensitive_and_superseded_by_default() {
+        let dir = tempdir().unwrap();
+        let mut store = SQLiteMemoryStore::open(dir.path().join("memory.sqlite")).unwrap();
+        let normal = MemoryEvent::new("Normal export memory.", "lesson").unwrap();
+        let mut sensitive = MemoryEvent::new("Private diagnosis export memory.", "lesson").unwrap();
+        sensitive.sensitivity = "health".to_string();
+        let mut superseded = MemoryEvent::new("Superseded export memory.", "lesson").unwrap();
+        superseded.superseded_by = Some(normal.id.clone());
+        store.put(&normal).unwrap();
+        store.put(&sensitive).unwrap();
+        store.put(&superseded).unwrap();
+
+        let (jsonl, report) = store.export_jsonl(false, false).unwrap();
+
+        assert_eq!(report.memory_count, 1);
+        assert!(jsonl.contains("Normal export memory."));
+        assert!(!jsonl.contains("Private diagnosis"));
+        assert!(!jsonl.contains("Superseded export memory."));
+    }
+
+    #[test]
+    fn import_jsonl_dry_run_validates_without_writing() {
+        let source_dir = tempdir().unwrap();
+        let target_dir = tempdir().unwrap();
+        let mut source = SQLiteMemoryStore::open(source_dir.path().join("memory.sqlite")).unwrap();
+        let event = MemoryEvent::new("Dry run import memory.", "lesson").unwrap();
+        source.put(&event).unwrap();
+        let (jsonl, _) = source.export_jsonl(false, false).unwrap();
+        let mut target = SQLiteMemoryStore::open(target_dir.path().join("memory.sqlite")).unwrap();
+
+        let report = target.import_jsonl(&jsonl, true, false).unwrap();
+
+        assert_eq!(report.valid_count, 1);
+        assert_eq!(report.inserted_count, 0);
+        assert!(target.list_all(false).unwrap().is_empty());
+    }
+
+    #[test]
+    fn import_jsonl_skips_duplicates_unless_replace_is_enabled() {
+        let source_dir = tempdir().unwrap();
+        let target_dir = tempdir().unwrap();
+        let mut source = SQLiteMemoryStore::open(source_dir.path().join("memory.sqlite")).unwrap();
+        let original = MemoryEvent::new("Original import memory.", "lesson").unwrap();
+        source.put(&original).unwrap();
+        let (jsonl, _) = source.export_jsonl(false, false).unwrap();
+        let mut target = SQLiteMemoryStore::open(target_dir.path().join("memory.sqlite")).unwrap();
+
+        let first = target.import_jsonl(&jsonl, false, false).unwrap();
+        let duplicate = target.import_jsonl(&jsonl, false, false).unwrap();
+
+        assert_eq!(first.inserted_count, 1);
+        assert_eq!(duplicate.inserted_count, 0);
+        assert_eq!(duplicate.skipped_duplicate_count, 1);
+
+        let mut replacement = original.clone();
+        replacement.summary = "Replacement import memory.".to_string();
+        let replacement_jsonl = encode_jsonl(&[replacement.clone()], false).unwrap();
+        let replaced = target
+            .import_jsonl(&replacement_jsonl, false, true)
+            .unwrap();
+
+        assert_eq!(replaced.replaced_count, 1);
+        assert_eq!(
+            target.get(&replacement.id).unwrap().unwrap().summary,
+            "Replacement import memory."
+        );
+    }
+
+    #[test]
+    fn import_jsonl_reclassifies_sensitive_and_blocks_secrets() {
+        let dir = tempdir().unwrap();
+        let mut store = SQLiteMemoryStore::open(dir.path().join("memory.sqlite")).unwrap();
+        let mut health =
+            MemoryEvent::new("Private diagnosis imported as normal.", "lesson").unwrap();
+        health.sensitivity = "normal".to_string();
+        let health_jsonl = encode_jsonl(&[health.clone()], false).unwrap();
+
+        let report = store.import_jsonl(&health_jsonl, false, false).unwrap();
+
+        assert_eq!(report.inserted_count, 1);
+        assert_eq!(
+            store.get(&health.id).unwrap().unwrap().sensitivity,
+            "health"
+        );
+
+        let secret = MemoryEvent::new(
+            "Imported secret sk-proj-abcdefghijklmnopqrstuvwxyz1234567890 must fail.",
+            "lesson",
+        )
+        .unwrap();
+        let secret_jsonl = encode_jsonl(&[secret], false).unwrap();
+
+        let err = store
+            .import_jsonl(&secret_jsonl, false, false)
+            .unwrap_err()
+            .to_string();
+
+        assert!(err.contains("blocked"));
+    }
+
+    #[test]
+    fn import_jsonl_applies_supersedes_to_existing_target_memory() {
+        let source_dir = tempdir().unwrap();
+        let target_dir = tempdir().unwrap();
+        let mut source = SQLiteMemoryStore::open(source_dir.path().join("memory.sqlite")).unwrap();
+        let mut target = SQLiteMemoryStore::open(target_dir.path().join("memory.sqlite")).unwrap();
+        let old = MemoryEvent::new("Old imported decision.", "decision").unwrap();
+        let mut new = MemoryEvent::new("New imported decision.", "decision").unwrap();
+        new.supersedes = vec![old.id.clone()];
+        target.put(&old).unwrap();
+        source.put(&new).unwrap();
+        let (jsonl, _) = source.export_jsonl(false, false).unwrap();
+
+        let report = target.import_jsonl(&jsonl, false, false).unwrap();
+
+        assert_eq!(report.inserted_count, 1);
+        assert_eq!(
+            target.get(&old.id).unwrap().unwrap().superseded_by,
+            Some(new.id.clone())
+        );
+        let active_ids: Vec<_> = target
+            .list_all(false)
+            .unwrap()
+            .into_iter()
+            .map(|event| event.id)
+            .collect();
+        assert_eq!(active_ids, vec![new.id]);
     }
 
     #[test]

--- a/docs/architecture/rust-core-roadmap.md
+++ b/docs/architecture/rust-core-roadmap.md
@@ -54,6 +54,10 @@ The Rust core must support:
 - delete, redact, and supersede workflows
 - JSON import/export compatibility with the published schemas
 
+v0.4 implements the JSONL import/export baseline in Rust and exposes it through
+the CLI and Python backends. Markdown exports, SQLite backups, and signed
+bundles remain future extension points.
+
 ## Non-Goals
 
 The Rust rewrite should not:

--- a/docs/architecture/rust-core-status.md
+++ b/docs/architecture/rust-core-status.md
@@ -2,8 +2,8 @@
 
 Tree Ring Memory has moved from a Python-owned reference implementation toward
 a Rust-first core with Python compatibility. This page tracks the v0.2 Rust
-core, v0.3 native Python binding work, and the Rust-native Ratatui terminal
-console now being added to the CLI.
+core, v0.3 native Python binding work, the Rust-native Ratatui terminal
+console, and the v0.4 Rust-owned JSONL import/export path.
 
 ## Current Status
 
@@ -27,6 +27,13 @@ console now being added to the CLI.
   contracts, including details, source metadata, agent profile, scores,
   retention, expiry, links, review metadata, supersession, recall filters,
   superseded-memory inclusion, and ranking explanations.
+- The v0.4 Rust core and SQLite store own portable JSONL import/export.
+  Exports exclude sensitive and superseded memories by default; import validates
+  events, supports dry-run previews, skips duplicate ids by default, and only
+  replaces existing rows when explicitly requested.
+- The Rust CLI exposes `tree-ring export` and `tree-ring import`; the optional
+  native Python backend and Python reference backend expose matching
+  `export_jsonl()` and `import_jsonl()` methods.
 - The Rust CLI now includes `tree-ring tui`, a Ratatui operator console with an
   always-visible animated ASCII tree-ring view, SQLite store-watch refresh,
   optional JSONL event-stream pulses, search/detail panes, and confirmation
@@ -39,6 +46,8 @@ cargo test
 python3 -m pytest
 cargo run -p tree-ring-memory-cli -- --help
 cargo run -p tree-ring-memory-cli -- tui --help
+cargo run -p tree-ring-memory-cli -- export --help
+cargo run -p tree-ring-memory-cli -- import --help
 python3 scripts/rust_performance_smoke.py --count 1000
 cargo build -p tree-ring-memory-python --features extension-module
 python3 scripts/native_binding_smoke.py --install-maturin
@@ -67,6 +76,8 @@ from tree_ring_memory import TreeRingMemory
 memory = TreeRingMemory.open(".tree-ring")
 event = memory.remember(summary="Native Rust path works.", event_type="lesson")
 results = memory.recall("Rust path")
+jsonl = memory.export_jsonl()
+preview = memory.import_jsonl(jsonl, dry_run=True)
 ```
 
 `NativeTreeRingMemory` requires the optional PyO3 extension module. Build it
@@ -86,16 +97,19 @@ Backend controls:
 ## Smoke Coverage
 
 - Rust unit tests cover model validation, sensitivity checks, recall scoring,
-  SQLite/FTS storage, transactional row/FTS consistency, redaction, and basic
-  concurrent writes. Rust binding tests cover native JSON remember/recall
-  round-trip and forget validation.
+  SQLite/FTS storage, transactional row/FTS consistency, redaction, JSONL
+  import/export filtering and duplicate handling, and basic concurrent writes.
+  Rust binding tests cover native JSON remember/recall round-trip, forget
+  validation, and JSONL import/export.
 - Rust CLI tests cover the scriptable init/remember/recall/forget commands and
-  the Ratatui TUI model, stream reader, slash-command parser, store-watch
-  refresh, confirmation-gated actions, CLI parsing, and render-buffer smoke.
+  JSONL import/export commands plus the Ratatui TUI model, stream reader,
+  slash-command parser, store-watch refresh, confirmation-gated actions, CLI
+  parsing, and render-buffer smoke.
 - Python tests cover the existing reference backend, Rust CLI database
   compatibility, the opt-in `RustCliTreeRingMemory` adapter, default facade
   native selection, full native wrapper argument marshalling, and clean
-  missing-extension behavior.
+  missing-extension behavior. They also cover Python reference and native
+  wrapper JSONL import/export parity.
 - `scripts/rust_performance_smoke.py` provides an operator-run local insert and
   recall timing check. It fails if expected recalls are empty, emits a stable
   `METRICS_JSON=` line, and enforces conservative synthetic-workload thresholds
@@ -103,10 +117,10 @@ Backend controls:
 
 Latest local smoke on July 5, 2026 with `--count 10000`:
 
-- Inserted 10,000 memories in 4,598.8 ms.
-- Insert throughput: 2,174.5 inserts/sec.
-- Recall average latency: 8.142 ms.
-- Recall max latency: 15.017 ms.
+- Inserted 10,000 memories in 4,577.9 ms.
+- Insert throughput: 2,184.4 inserts/sec.
+- Recall average latency: 6.109 ms.
+- Recall max latency: 9.266 ms.
 
 ## Compatibility Rule
 

--- a/docs/superpowers/plans/2026-07-05-tree-ring-memory-rust-import-export-v0-4-implementation-plan.md
+++ b/docs/superpowers/plans/2026-07-05-tree-ring-memory-rust-import-export-v0-4-implementation-plan.md
@@ -1,0 +1,129 @@
+# Tree Ring Memory Rust Import/Export v0.4 Implementation Plan
+
+## Goal
+
+Implement Rust-owned JSONL import/export for Tree Ring Memory while preserving
+Python compatibility and privacy defaults.
+
+## Constraints
+
+- Keep the framework local-first and framework-agnostic.
+- Do not add external services or dependencies unless already present.
+- Sensitive memories must be excluded from export by default.
+- Superseded memories must be excluded from export by default.
+- Import validates schema before storage.
+- Import dry-run must not mutate storage.
+- Do not remove the Python reference backend.
+
+## Task 1: Rust Import/Export Format
+
+Add a Rust import/export module in `tree-ring-memory-core`.
+
+Required behavior:
+
+- Encode JSONL with a metadata header.
+- Encode memory event envelopes as `{"type":"memory_event","memory":...}`.
+- Decode JSONL containing header lines, envelope lines, and raw `MemoryEvent`
+  JSON lines.
+- Validate decoded memory events.
+- Ignore blank lines.
+- Return line-numbered parse errors.
+
+Verification:
+
+```bash
+cargo test -p tree-ring-memory-core import_export
+```
+
+## Task 2: Rust Store Import/Export Operations
+
+Add storage-level helpers in `tree-ring-memory-sqlite`.
+
+Required behavior:
+
+- Export events filtered by `include_sensitive` and `include_superseded`.
+- Import events with `dry_run` and `replace_existing` options.
+- Skip duplicates by default.
+- Replace duplicates only when explicitly requested.
+- Return structured import/export reports.
+
+Verification:
+
+```bash
+cargo test -p tree-ring-memory-sqlite import_export
+```
+
+## Task 3: Rust CLI Commands
+
+Add scriptable CLI commands:
+
+```bash
+tree-ring export --output memories.jsonl
+tree-ring export --include-sensitive --include-superseded
+tree-ring import memories.jsonl --dry-run
+tree-ring import memories.jsonl --replace-existing
+```
+
+Required behavior:
+
+- Export to stdout when `--output` is absent.
+- Write reports when output/import actions complete.
+- Respect global `--json` for operation reports where useful.
+- Never emit sensitive rows unless `--include-sensitive` is set.
+- Add CLI tests through the existing Python subprocess harness.
+
+Verification:
+
+```bash
+cargo test -p tree-ring-memory-cli
+python3 -m pytest tests/test_cli.py
+```
+
+## Task 4: Native Python Wrapper
+
+Expose import/export from the optional native backend.
+
+Required behavior:
+
+- `NativeTreeRingMemory.export_jsonl(...) -> str`
+- `NativeTreeRingMemory.import_jsonl(..., dry_run=False, replace_existing=False) -> dict`
+- The methods call Rust native bindings when installed.
+- The Python reference backend may expose equivalent methods for parity, but
+  Rust remains the target owner.
+
+Verification:
+
+```bash
+cargo test -p tree-ring-memory-python
+python3 -m pytest tests/test_cli.py
+python3 scripts/native_binding_smoke.py --install-maturin
+```
+
+## Task 5: Docs And Final Verification
+
+Update README and Rust status docs.
+
+Verification:
+
+```bash
+cargo fmt
+cargo test
+python3 -m pytest
+cargo run -p tree-ring-memory-cli -- export --help
+cargo run -p tree-ring-memory-cli -- import --help
+cargo build -p tree-ring-memory-python --features extension-module
+python3 scripts/native_binding_smoke.py --install-maturin
+python3 scripts/rust_performance_smoke.py --count 10000
+```
+
+## Definition Of Done
+
+- Rust exports JSONL memory bundles.
+- Rust imports JSONL memory bundles.
+- Sensitive memory is excluded by default.
+- Superseded memory is excluded by default.
+- Import dry-run is non-mutating.
+- Duplicate import behavior is explicit and tested.
+- Native Python wrapper exposes the Rust behavior.
+- README documents the feature.
+- Tests and smoke checks pass.

--- a/docs/superpowers/specs/2026-07-05-tree-ring-memory-rust-import-export-v0-4-design.md
+++ b/docs/superpowers/specs/2026-07-05-tree-ring-memory-rust-import-export-v0-4-design.md
@@ -1,0 +1,86 @@
+# Tree Ring Memory Rust Import/Export v0.4 Design
+
+## Summary
+
+v0.4 closes the next Rust migration gap: portable local memory import and
+export. Tree Ring Memory needs a framework-agnostic way to back up, review, and
+migrate memory without exposing sensitive rows by default and without relying on
+Python as the behavioral owner.
+
+The first v0.4 target is JSONL. SQLite backups, markdown reports, and richer
+bundle signing can follow later.
+
+## Goals
+
+- Add Rust-owned JSONL export.
+- Add Rust-owned JSONL import.
+- Keep the format portable and line-oriented for CLI agents and Unix tooling.
+- Exclude sensitive memory from export by default.
+- Exclude superseded memory from export by default.
+- Support dry-run import previews.
+- Support merge-style import that skips duplicate ids by default.
+- Expose the behavior through the Rust CLI.
+- Expose the behavior through the optional native Python backend.
+
+## Non-Goals
+
+- No cloud sync.
+- No external storage services.
+- No automatic disk ingestion.
+- No markdown or SQLite backup format in this phase.
+- No consolidation/audit implementation in this phase.
+- No forced removal of the Python reference backend.
+
+## JSONL Format
+
+The export is newline-delimited JSON.
+
+The first line is a metadata header:
+
+```json
+{"type":"tree_ring_memory_export","schema_version":1,"plugin_version":"0.4.0","created_at":"...","memory_count":2,"sensitive_included":false}
+```
+
+Each memory line is an envelope:
+
+```json
+{"type":"memory_event","memory":{... MemoryEvent JSON ...}}
+```
+
+Import accepts both the envelope form and raw `MemoryEvent` JSON lines so older
+or hand-edited exports remain usable.
+
+## Safety
+
+- Export excludes non-normal sensitivity unless `--include-sensitive` is set.
+- Export excludes superseded memory unless `--include-superseded` is set.
+- Import validates every memory event before writing.
+- Import dry-run validates and reports counts without mutating storage.
+- Import skips duplicate ids by default.
+- Import only replaces existing rows when `--replace-existing` is set.
+
+## CLI Shape
+
+```bash
+tree-ring export --output memories.jsonl
+tree-ring export --include-sensitive --include-superseded
+tree-ring import memories.jsonl --dry-run
+tree-ring import memories.jsonl --replace-existing
+```
+
+`--json` returns operation reports for output-file export and import. When
+exporting to stdout, the command emits JSONL because that is the requested data
+stream.
+
+## Acceptance
+
+1. Rust can export JSONL from SQLite.
+2. Rust can import JSONL into a new store.
+3. Sensitive memory is excluded by default.
+4. Superseded memory is excluded by default.
+5. Import dry-run does not mutate storage.
+6. Duplicate import is skipped by default.
+7. Replace import can overwrite existing ids.
+8. Python can read Rust-exported/Rust-imported stores.
+9. Native Python wrapper exposes import/export when the extension is installed.
+10. Rust and Python tests pass.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tree-ring-memory"
-version = "0.1.0"
+version = "0.4.0"
 description = "Framework-agnostic tree-ring memory for AI agents."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/scripts/native_binding_smoke.py
+++ b/scripts/native_binding_smoke.py
@@ -60,6 +60,15 @@ def main() -> int:
                     "event = memory.remember(summary='Native default facade works.', event_type='lesson'); "
                     "results = memory.recall('native facade'); "
                     "assert results and results[0].memory.id == event.id; "
+                    "jsonl = memory.export_jsonl(); "
+                    "assert 'tree_ring_memory_export' in jsonl; "
+                    "target = TreeRingMemory.open(Path(tempfile.mkdtemp()) / '.tree-ring'); "
+                    "preview = target.import_jsonl(jsonl, dry_run=True); "
+                    "assert preview['valid_count'] == 1 and preview['inserted_count'] == 0; "
+                    "report = target.import_jsonl(jsonl); "
+                    "assert report['inserted_count'] == 1; "
+                    "imported = target.recall('native facade'); "
+                    "assert imported and imported[0].memory.id == event.id; "
                     "print(native.native_version())"
                 ),
             ]

--- a/src/tree_ring_memory/api.py
+++ b/src/tree_ring_memory/api.py
@@ -155,6 +155,30 @@ class PythonTreeRingMemory:
 
         raise ValueError(f"unsupported forget mode: {mode}")
 
+    def export_jsonl(
+        self,
+        *,
+        include_sensitive: bool = False,
+        include_superseded: bool = False,
+    ) -> str:
+        return self.store.export_jsonl(
+            include_sensitive=include_sensitive,
+            include_superseded=include_superseded,
+        )
+
+    def import_jsonl(
+        self,
+        data: str,
+        *,
+        dry_run: bool = False,
+        replace_existing: bool = False,
+    ) -> dict:
+        return self.store.import_jsonl(
+            data,
+            dry_run=dry_run,
+            replace_existing=replace_existing,
+        )
+
     def _check_public_text_fields(self, *values: str | None) -> list[SensitivityResult]:
         return [self._sensitivity_guard.check_or_raise(value or "") for value in values]
 

--- a/src/tree_ring_memory/native_backend.py
+++ b/src/tree_ring_memory/native_backend.py
@@ -124,6 +124,33 @@ class NativeTreeRingMemory:
     def forget(self, memory_id: str, *, mode: str, reason: str) -> None:
         self._native.forget(memory_id, mode, reason)
 
+    def export_jsonl(
+        self,
+        *,
+        include_sensitive: bool = False,
+        include_superseded: bool = False,
+    ) -> str:
+        return str(
+            self._native.export_jsonl(
+                include_sensitive=include_sensitive,
+                include_superseded=include_superseded,
+            )
+        )
+
+    def import_jsonl(
+        self,
+        data: str,
+        *,
+        dry_run: bool = False,
+        replace_existing: bool = False,
+    ) -> dict[str, Any]:
+        payload = self._native.import_jsonl(
+            data,
+            dry_run=dry_run,
+            replace_existing=replace_existing,
+        )
+        return dict(json.loads(payload))
+
 
 def _iso_or_none(value: Any) -> str | None:
     if value is None:

--- a/src/tree_ring_memory/store.py
+++ b/src/tree_ring_memory/store.py
@@ -220,17 +220,20 @@ class SQLiteMemoryStore:
         if dry_run:
             return report
 
+        imported_events = []
         for event in events:
             if self.get(event.id) is None:
                 self.put(event)
-                self._apply_supersedes(event)
+                imported_events.append(event)
                 report["inserted_count"] += 1
             elif replace_existing:
                 self.put(event)
-                self._apply_supersedes(event)
+                imported_events.append(event)
                 report["replaced_count"] += 1
             else:
                 report["skipped_duplicate_count"] += 1
+        for event in imported_events:
+            self._apply_supersedes(event)
         return report
 
     def _apply_supersedes(self, event: MemoryEvent) -> None:

--- a/src/tree_ring_memory/store.py
+++ b/src/tree_ring_memory/store.py
@@ -4,10 +4,17 @@ import json
 from pathlib import Path
 import re
 import sqlite3
+from typing import Any
 
 from tree_ring_memory.models import MemoryEvent
+from tree_ring_memory.models import now_utc
+from tree_ring_memory.sensitivity import SensitivityGuard
 
 
+EXPORT_RECORD_TYPE = "tree_ring_memory_export"
+MEMORY_EVENT_RECORD_TYPE = "memory_event"
+EXPORT_SCHEMA_VERSION = 1
+PLUGIN_VERSION = "0.4.0"
 _PLAIN_TEXT_TERM_RE = re.compile(r"\w+")
 _SEARCH_FILLER_TERMS = {
     "a",
@@ -177,6 +184,59 @@ class SQLiteMemoryStore:
             self.connection.execute("DELETE FROM memories WHERE id = ?", (memory_id,))
             self.connection.execute("DELETE FROM memory_fts WHERE id = ?", (memory_id,))
 
+    def export_jsonl(self, *, include_sensitive: bool = False, include_superseded: bool = False) -> str:
+        events = [
+            event
+            for event in self.list_all(include_superseded=include_superseded)
+            if include_sensitive or event.sensitivity == "normal"
+        ]
+        header = {
+            "type": EXPORT_RECORD_TYPE,
+            "schema_version": EXPORT_SCHEMA_VERSION,
+            "plugin_version": PLUGIN_VERSION,
+            "created_at": now_utc().isoformat(),
+            "memory_count": len(events),
+            "sensitive_included": include_sensitive,
+        }
+        records = [header]
+        records.extend({"type": MEMORY_EVENT_RECORD_TYPE, "memory": event.to_dict()} for event in events)
+        return "".join(f"{json.dumps(record, sort_keys=True)}\n" for record in records)
+
+    def import_jsonl(
+        self,
+        data: str,
+        *,
+        dry_run: bool = False,
+        replace_existing: bool = False,
+    ) -> dict[str, Any]:
+        events = _normalize_import_events(_decode_jsonl(data))
+        report = {
+            "valid_count": len(events),
+            "inserted_count": 0,
+            "replaced_count": 0,
+            "skipped_duplicate_count": 0,
+            "dry_run": dry_run,
+        }
+        if dry_run:
+            return report
+
+        for event in events:
+            if self.get(event.id) is None:
+                self.put(event)
+                self._apply_supersedes(event)
+                report["inserted_count"] += 1
+            elif replace_existing:
+                self.put(event)
+                self._apply_supersedes(event)
+                report["replaced_count"] += 1
+            else:
+                report["skipped_duplicate_count"] += 1
+        return report
+
+    def _apply_supersedes(self, event: MemoryEvent) -> None:
+        for old_id in event.supersedes:
+            self.supersede(old_id, event.id)
+
     def close(self) -> None:
         self.connection.close()
 
@@ -192,3 +252,100 @@ def _format_plain_text_fts_query(query: str) -> str:
         if term.casefold() not in _SEARCH_FILLER_TERMS
     ]
     return " AND ".join(f'"{term}"' for term in terms)
+
+
+def _decode_jsonl(data: str) -> list[MemoryEvent]:
+    events: list[MemoryEvent] = []
+    for index, line in enumerate(data.splitlines(), start=1):
+        trimmed = line.strip()
+        if not trimmed:
+            continue
+        try:
+            value = json.loads(trimmed)
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"line {index}: invalid json: {exc}") from exc
+
+        record_type = value.get("type") if isinstance(value, dict) else None
+        try:
+            if record_type == EXPORT_RECORD_TYPE:
+                _validate_export_header(value)
+                continue
+            if record_type == MEMORY_EVENT_RECORD_TYPE:
+                events.append(MemoryEvent.from_dict(value.get("memory") or {}))
+                continue
+            events.append(MemoryEvent.from_dict(value))
+        except Exception as exc:
+            raise ValueError(f"line {index}: {exc}") from exc
+    return events
+
+
+def _validate_export_header(value: dict[str, Any]) -> None:
+    required = {
+        "type",
+        "schema_version",
+        "plugin_version",
+        "created_at",
+        "memory_count",
+        "sensitive_included",
+    }
+    missing = sorted(required.difference(value))
+    if missing:
+        raise ValueError(f"missing export header fields: {', '.join(missing)}")
+    schema_version = value.get("schema_version")
+    if schema_version != EXPORT_SCHEMA_VERSION:
+        raise ValueError(f"unsupported export schema version {schema_version}")
+    if not isinstance(value.get("plugin_version"), str) or not value["plugin_version"]:
+        raise ValueError("plugin_version must be a non-empty string")
+    if not isinstance(value.get("created_at"), str) or not value["created_at"]:
+        raise ValueError("created_at must be a non-empty string")
+    if not isinstance(value.get("memory_count"), int) or value["memory_count"] < 0:
+        raise ValueError("memory_count must be a non-negative integer")
+    if not isinstance(value.get("sensitive_included"), bool):
+        raise ValueError("sensitive_included must be a boolean")
+
+
+def _normalize_import_events(events: list[MemoryEvent]) -> list[MemoryEvent]:
+    return [_normalize_import_event(event) for event in events]
+
+
+def _normalize_import_event(event: MemoryEvent) -> MemoryEvent:
+    guard = SensitivityGuard()
+    detected = "normal"
+    for value in _event_text_values(event):
+        result = guard.check_or_raise(value or "")
+        if detected == "normal" and result.sensitivity != "normal":
+            detected = result.sensitivity
+    if event.sensitivity == "normal" and detected != "normal":
+        event.sensitivity = detected
+    event.validate()
+    return event
+
+
+def _event_text_values(event: MemoryEvent) -> list[str | None]:
+    values: list[str | None] = [
+        event.id,
+        event.created_at.isoformat(),
+        event.updated_at.isoformat(),
+        event.project,
+        event.agent_profile,
+        event.scope,
+        event.ring,
+        event.event_type,
+        event.summary,
+        event.details,
+        event.source.type,
+        event.source.ref,
+        event.source.quote,
+        event.sensitivity,
+        event.retention,
+        event.expires_at.isoformat() if event.expires_at else None,
+        event.superseded_by,
+        event.review.review_reason,
+        event.review.reviewed_at,
+        event.review.reviewed_by,
+    ]
+    values.extend(event.tags)
+    values.extend(event.supersedes)
+    for link in event.links:
+        values.extend([link.type, link.target])
+    return values

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -10,7 +10,7 @@ import pytest
 from tree_ring_memory import TreeRingMemory
 import tree_ring_memory.native_backend as native_backend
 from tree_ring_memory.native_backend import NativeTreeRingMemory
-from tree_ring_memory.models import MemoryLink, MemoryReview, MemorySource
+from tree_ring_memory.models import MemoryEvent, MemoryLink, MemoryReview, MemorySource
 from tree_ring_memory.store import SQLiteMemoryStore
 from tree_ring_memory.rust_backend import RustCliTreeRingMemory
 
@@ -167,6 +167,148 @@ def test_rust_cli_json_contract_for_init_remember_recall_and_forget(tmp_path):
     assert forgotten.returncode == 0, forgotten.stderr
     forget_payload = json.loads(forgotten.stdout)
     assert forget_payload == {"ok": True, "memory_id": memory_payload["id"]}
+
+
+def test_rust_cli_export_import_jsonl_round_trip(tmp_path):
+    source_root = tmp_path / "source" / ".tree-ring"
+    target_root = tmp_path / "target" / ".tree-ring"
+    export_path = tmp_path / "memories.jsonl"
+
+    remembered = run_rust_cli(
+        source_root,
+        "--json",
+        "remember",
+        "Exported Rust memory survives import.",
+        "--event-type",
+        "lesson",
+        "--project",
+        "compat",
+        "--tag",
+        "export",
+    )
+    assert remembered.returncode == 0, remembered.stderr
+    memory_payload = json.loads(remembered.stdout)
+
+    exported = run_rust_cli(source_root, "--json", "export", "--output", str(export_path))
+    assert exported.returncode == 0, exported.stderr
+    export_report = json.loads(exported.stdout)
+    assert export_report["memory_count"] == 1
+    assert export_path.exists()
+    exported_lines = [json.loads(line) for line in export_path.read_text().splitlines()]
+    assert exported_lines[0]["type"] == "tree_ring_memory_export"
+    assert exported_lines[0]["schema_version"] == 1
+    assert exported_lines[0]["plugin_version"] == "0.4.0"
+    assert exported_lines[1]["type"] == "memory_event"
+
+    preview = run_rust_cli(target_root, "--json", "import", str(export_path), "--dry-run")
+    assert preview.returncode == 0, preview.stderr
+    preview_report = json.loads(preview.stdout)
+    assert preview_report["valid_count"] == 1
+    assert preview_report["inserted_count"] == 0
+    assert not target_root.exists()
+
+    imported = run_rust_cli(target_root, "--json", "import", str(export_path))
+    assert imported.returncode == 0, imported.stderr
+    import_report = json.loads(imported.stdout)
+    assert import_report["inserted_count"] == 1
+    assert import_report["skipped_duplicate_count"] == 0
+
+    recalled = run_rust_cli(target_root, "--json", "recall", "survives import", "--project", "compat")
+    assert recalled.returncode == 0, recalled.stderr
+    recall_payload = json.loads(recalled.stdout)
+    assert recall_payload[0]["memory"]["id"] == memory_payload["id"]
+
+
+def test_rust_cli_export_excludes_sensitive_by_default(tmp_path):
+    root = tmp_path / ".tree-ring"
+    normal = run_rust_cli(
+        root,
+        "--json",
+        "remember",
+        "Normal export memory.",
+        "--event-type",
+        "lesson",
+    )
+    assert normal.returncode == 0, normal.stderr
+    sensitive = run_rust_cli(
+        root,
+        "--json",
+        "remember",
+        "Private diagnosis should require explicit export.",
+        "--event-type",
+        "lesson",
+    )
+    assert sensitive.returncode == 0, sensitive.stderr
+
+    default_export = run_rust_cli(root, "export")
+    assert default_export.returncode == 0, default_export.stderr
+    assert "Normal export memory." in default_export.stdout
+    assert "Private diagnosis" not in default_export.stdout
+
+    sensitive_export = run_rust_cli(root, "export", "--include-sensitive")
+    assert sensitive_export.returncode == 0, sensitive_export.stderr
+    assert "Private diagnosis" in sensitive_export.stdout
+
+
+def test_rust_cli_import_skips_duplicates_by_default(tmp_path):
+    source_root = tmp_path / "source" / ".tree-ring"
+    target_root = tmp_path / "target" / ".tree-ring"
+    export_path = tmp_path / "memories.jsonl"
+
+    remembered = run_rust_cli(
+        source_root,
+        "--json",
+        "remember",
+        "Duplicate import should skip existing id.",
+        "--event-type",
+        "lesson",
+    )
+    assert remembered.returncode == 0, remembered.stderr
+    run_rust_cli(source_root, "export", "--output", str(export_path))
+
+    first = run_rust_cli(target_root, "--json", "import", str(export_path))
+    second = run_rust_cli(target_root, "--json", "import", str(export_path))
+
+    assert first.returncode == 0, first.stderr
+    assert second.returncode == 0, second.stderr
+    first_report = json.loads(first.stdout)
+    second_report = json.loads(second.stdout)
+    assert first_report["inserted_count"] == 1
+    assert second_report["inserted_count"] == 0
+    assert second_report["skipped_duplicate_count"] == 1
+
+
+def test_rust_cli_import_dry_run_blocks_secret_without_creating_root(tmp_path):
+    target_root = tmp_path / "target" / ".tree-ring"
+    export_path = tmp_path / "secret.jsonl"
+    secret = MemoryEvent.new(
+        summary="Imported secret sk-proj-abcdefghijklmnopqrstuvwxyz1234567890 must fail.",
+        event_type="lesson",
+    )
+    export_path.write_text(
+        "\n".join(
+            [
+                json.dumps(
+                    {
+                        "type": "tree_ring_memory_export",
+                        "schema_version": 1,
+                        "plugin_version": "0.4.0",
+                        "created_at": "2026-07-05T00:00:00+00:00",
+                        "memory_count": 1,
+                        "sensitive_included": True,
+                    }
+                ),
+                json.dumps({"type": "memory_event", "memory": secret.to_dict()}),
+            ]
+        )
+        + "\n"
+    )
+
+    preview = run_rust_cli(target_root, "--json", "import", str(export_path), "--dry-run")
+
+    assert preview.returncode == 2
+    assert "blocked" in preview.stderr
+    assert not target_root.exists()
 
 
 def test_python_written_rich_memory_is_rust_recall_json_readable(tmp_path):

--- a/tests/test_import_export.py
+++ b/tests/test_import_export.py
@@ -1,0 +1,189 @@
+import json
+
+from tree_ring_memory import NativeTreeRingMemory, PythonTreeRingMemory
+from tree_ring_memory.models import MemoryEvent
+
+
+def test_python_reference_jsonl_export_import_round_trip(tmp_path):
+    source = PythonTreeRingMemory.open(tmp_path / "source")
+    target = PythonTreeRingMemory.open(tmp_path / "target")
+    event = source.remember(
+        summary="Python JSONL round trip uses the shared schema.",
+        event_type="lesson",
+        project="compat",
+    )
+
+    jsonl = source.export_jsonl()
+    dry_run_report = target.import_jsonl(jsonl, dry_run=True)
+    import_report = target.import_jsonl(jsonl)
+
+    header = json.loads(jsonl.splitlines()[0])
+    assert header["type"] == "tree_ring_memory_export"
+    assert header["schema_version"] == 1
+    assert header["plugin_version"] == "0.4.0"
+    assert event.id in jsonl
+    assert dry_run_report == {
+        "valid_count": 1,
+        "inserted_count": 0,
+        "replaced_count": 0,
+        "skipped_duplicate_count": 0,
+        "dry_run": True,
+    }
+    assert import_report["inserted_count"] == 1
+    assert target.recall("shared schema", project="compat")[0].memory.id == event.id
+
+
+def test_python_reference_jsonl_duplicate_and_replace_reports(tmp_path):
+    memory = PythonTreeRingMemory.open(tmp_path / ".tree-ring")
+    event = memory.remember(summary="Original duplicate memory.", event_type="lesson")
+    replacement = event.to_dict()
+    replacement["summary"] = "Replacement duplicate memory."
+    jsonl = json.dumps({"type": "memory_event", "memory": replacement}) + "\n"
+
+    skipped = memory.import_jsonl(jsonl)
+    replaced = memory.import_jsonl(jsonl, replace_existing=True)
+
+    assert skipped["skipped_duplicate_count"] == 1
+    assert replaced["replaced_count"] == 1
+    assert memory.store.get(event.id).summary == "Replacement duplicate memory."
+
+
+def test_python_reference_jsonl_export_filters_sensitive_and_superseded(tmp_path):
+    memory = PythonTreeRingMemory.open(tmp_path / ".tree-ring")
+    old = memory.remember(summary="Old public decision.", event_type="decision")
+    memory.remember(
+        summary="New public decision.",
+        event_type="decision",
+        supersedes=[old.id],
+    )
+    sensitive = memory.remember(
+        summary="Private import export context.",
+        event_type="lesson",
+        sensitivity="private",
+    )
+
+    default_jsonl = memory.export_jsonl()
+    full_jsonl = memory.export_jsonl(include_sensitive=True, include_superseded=True)
+    default_memory_ids = _memory_ids(default_jsonl)
+    full_memory_ids = _memory_ids(full_jsonl)
+
+    assert old.id not in default_memory_ids
+    assert sensitive.id not in default_memory_ids
+    assert old.id in full_memory_ids
+    assert sensitive.id in full_memory_ids
+
+
+def test_python_reference_import_reclassifies_sensitive_and_blocks_secrets(tmp_path):
+    memory = PythonTreeRingMemory.open(tmp_path / ".tree-ring")
+    health = MemoryEvent.new(
+        summary="Private diagnosis imported as normal.",
+        event_type="lesson",
+        sensitivity="normal",
+    )
+    health_jsonl = json.dumps({"type": "memory_event", "memory": health.to_dict()}) + "\n"
+
+    report = memory.import_jsonl(health_jsonl)
+
+    assert report["inserted_count"] == 1
+    assert memory.store.get(health.id).sensitivity == "health"
+
+    secret = MemoryEvent.new(
+        summary="Imported secret sk-proj-abcdefghijklmnopqrstuvwxyz1234567890 must fail.",
+        event_type="lesson",
+    )
+    secret_jsonl = json.dumps({"type": "memory_event", "memory": secret.to_dict()}) + "\n"
+
+    try:
+        memory.import_jsonl(secret_jsonl)
+    except ValueError as exc:
+        assert "blocked" in str(exc)
+    else:
+        raise AssertionError("secret import should have been blocked")
+
+
+def test_python_reference_import_applies_supersedes_to_existing_target(tmp_path):
+    source = PythonTreeRingMemory.open(tmp_path / "source")
+    target = PythonTreeRingMemory.open(tmp_path / "target")
+    old = target.remember(summary="Old imported decision.", event_type="decision")
+    new = source.remember(
+        summary="New imported decision.",
+        event_type="decision",
+        supersedes=[old.id],
+    )
+    jsonl = source.export_jsonl()
+
+    report = target.import_jsonl(jsonl)
+
+    assert report["inserted_count"] == 1
+    assert target.store.get(old.id).superseded_by == new.id
+    assert [event.id for event in target.store.list_all()] == [new.id]
+
+
+def test_python_reference_jsonl_rejects_malformed_export_header(tmp_path):
+    memory = PythonTreeRingMemory.open(tmp_path / ".tree-ring")
+    malformed = json.dumps({"type": "tree_ring_memory_export", "schema_version": 1}) + "\n"
+
+    try:
+        memory.import_jsonl(malformed, dry_run=True)
+    except ValueError as exc:
+        assert "missing export header fields" in str(exc)
+        assert "plugin_version" in str(exc)
+    else:
+        raise AssertionError("malformed export header should have been rejected")
+
+
+def test_native_backend_jsonl_methods_delegate_to_binding(tmp_path):
+    class FakeNativeStore:
+        def __init__(self):
+            self.export_kwargs = None
+            self.import_kwargs = None
+
+        def export_jsonl(self, *, include_sensitive=False, include_superseded=False):
+            self.export_kwargs = {
+                "include_sensitive": include_sensitive,
+                "include_superseded": include_superseded,
+            }
+            return '{"type":"tree_ring_memory_export"}\n'
+
+        def import_jsonl(self, data, *, dry_run=False, replace_existing=False):
+            self.import_kwargs = {
+                "data": data,
+                "dry_run": dry_run,
+                "replace_existing": replace_existing,
+            }
+            return json.dumps(
+                {
+                    "valid_count": 1,
+                    "inserted_count": 0,
+                    "replaced_count": 0,
+                    "skipped_duplicate_count": 0,
+                    "dry_run": dry_run,
+                }
+            )
+
+    fake_native = FakeNativeStore()
+    memory = NativeTreeRingMemory(fake_native, tmp_path / ".tree-ring")
+
+    jsonl = memory.export_jsonl(include_sensitive=True, include_superseded=True)
+    report = memory.import_jsonl(jsonl, dry_run=True, replace_existing=True)
+
+    assert fake_native.export_kwargs == {
+        "include_sensitive": True,
+        "include_superseded": True,
+    }
+    assert fake_native.import_kwargs == {
+        "data": jsonl,
+        "dry_run": True,
+        "replace_existing": True,
+    }
+    assert report["valid_count"] == 1
+    assert report["dry_run"] is True
+
+
+def _memory_ids(jsonl: str) -> set[str]:
+    ids = set()
+    for line in jsonl.splitlines():
+        record = json.loads(line)
+        if record.get("type") == "memory_event":
+            ids.add(record["memory"]["id"])
+    return ids

--- a/tests/test_import_export.py
+++ b/tests/test_import_export.py
@@ -119,6 +119,38 @@ def test_python_reference_import_applies_supersedes_to_existing_target(tmp_path)
     assert [event.id for event in target.store.list_all()] == [new.id]
 
 
+def test_python_reference_import_applies_supersedes_after_all_rows_are_written(tmp_path):
+    memory = PythonTreeRingMemory.open(tmp_path / ".tree-ring")
+    old = MemoryEvent.new(summary="Old decision imported after replacement.", event_type="decision")
+    new = MemoryEvent.new(
+        summary="New decision imported before old.",
+        event_type="decision",
+        supersedes=[old.id],
+    )
+    jsonl = "\n".join(
+        [
+            json.dumps(
+                {
+                    "type": "tree_ring_memory_export",
+                    "schema_version": 1,
+                    "plugin_version": "0.4.0",
+                    "created_at": "2026-07-05T00:00:00+00:00",
+                    "memory_count": 2,
+                    "sensitive_included": False,
+                }
+            ),
+            json.dumps({"type": "memory_event", "memory": new.to_dict()}),
+            json.dumps({"type": "memory_event", "memory": old.to_dict()}),
+        ]
+    )
+
+    report = memory.import_jsonl(jsonl)
+
+    assert report["inserted_count"] == 2
+    assert memory.store.get(old.id).superseded_by == new.id
+    assert [event.id for event in memory.store.list_all()] == [new.id]
+
+
 def test_python_reference_jsonl_rejects_malformed_export_header(tmp_path):
     memory = PythonTreeRingMemory.open(tmp_path / ".tree-ring")
     malformed = json.dumps({"type": "tree_ring_memory_export", "schema_version": 1}) + "\n"

--- a/tests/test_native_packaging.py
+++ b/tests/test_native_packaging.py
@@ -12,6 +12,6 @@ def test_native_binding_pyproject_is_extension_only():
     maturin = pyproject["tool"]["maturin"]
 
     assert pyproject["project"]["name"] == "tree-ring-memory-native"
-    assert pyproject["project"]["version"] == "0.3.0"
+    assert pyproject["project"]["version"] == "0.4.0"
     assert maturin["module-name"] == "tree_ring_memory._tree_ring_memory_native"
     assert maturin["python-source"] == "python"


### PR DESCRIPTION
Summary:
- Add Rust-owned JSONL import/export format, SQLite operations, and CLI commands.
- Expose import/export through the PyO3 native backend and Python reference facade with matching privacy defaults.
- Harden imports with sensitivity normalization, secret blocking, dry-run non-mutation, duplicate handling, supersession side effects, and parser parity tests.
- Update README, Rust status/roadmap docs, package versions, and native smoke coverage for v0.4.0.

Verification:
- cargo fmt --check: passed.
- git diff --check: passed.
- cargo test: passed.
- python3 -m pytest: 91 passed.
- cargo run -q -p tree-ring-memory-cli -- export --help: passed.
- cargo run -q -p tree-ring-memory-cli -- import --help: passed.
- cargo build -p tree-ring-memory-python --features extension-module: passed.
- python3 scripts/native_binding_smoke.py --install-maturin: passed; native_version reported 0.4.0 and JSONL import/export round trip passed.
- python3 scripts/rust_performance_smoke.py --count 10000: passed; 10,000 inserts, 2,184.4 inserts/sec, recall avg 6.109 ms, max 9.266 ms.

Review gates:
- Spec review requested a dry-run fix; fixed and re-reviewed approved.
- Code-quality review requested import privacy/supersession/parser fixes; fixed and re-reviewed approved.

Notes:
- .vscode/ remains untracked and was not included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added JSONL export and import support across the CLI, Python APIs, and native backend.
  * Exports now include a header and structured memory entries, with dry-run import previews and duplicate-handling options.

* **Bug Fixes**
  * Improved import validation with clearer error reporting for malformed data.
  * Default exports now exclude sensitive and superseded memories unless explicitly included.

* **Chores**
  * Updated project and package versions to 0.4.0.
  * Expanded documentation and test coverage for the new release workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->