### PR TITLE
Add installer and terminal onboarding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1759,7 +1759,7 @@ checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "tree-ring-memory-cli"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "clap",
  "ratatui",
@@ -1772,7 +1772,7 @@ dependencies = [
 
 [[package]]
 name = "tree-ring-memory-core"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "chrono",
  "once_cell",
@@ -1785,7 +1785,7 @@ dependencies = [
 
 [[package]]
 name = "tree-ring-memory-python"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "pyo3",
  "pyo3-build-config",
@@ -1798,7 +1798,7 @@ dependencies = [
 
 [[package]]
 name = "tree-ring-memory-sqlite"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "rusqlite",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.9.0"
+version = "0.10.0"
 edition = "2021"
 license = "MIT"
 authors = ["TerminallyLazy"]

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Tree Ring Memory is in protocol-preview status.
 - v0.7 makes the public facade Rust-native only and adds Rust-owned maintenance for expiry, secret redaction, and FTS repair.
 - v0.8 removes Python-owned runtime behavior; Python is now a thin native-binding surface only.
 - v0.9 removes tracked Python source, tests, and smoke scripts from the canonical repo; the optional CPython extension is Rust-built.
+- v0.10 adds a one-line installer plus Rust-native terminal onboarding with ASCII tree rings.
 - The Rust CLI also includes a Ratatui operator console behind `tree-ring tui`.
 
 The Rust workspace currently includes:
@@ -38,6 +39,52 @@ The public runtime is Rust-native. The Rust CLI and Rust crates own storage,
 recall, import/export, audit, consolidation, maintenance, and terminal UI
 behavior. There is no tracked root Python package, Python wrapper layer, pytest
 suite, or Python smoke script.
+
+## Install
+
+Global user install:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/TerminallyLazy/Tree-Ring-Memory/main/install.sh | sh
+```
+
+Project-local install with first-run initialization:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/TerminallyLazy/Tree-Ring-Memory/main/install.sh | sh -s -- --project --init
+```
+
+The installer builds the Rust CLI with `cargo`, installs `tree-ring`, then shows
+a short terminal onboarding screen with ASCII rings and the next useful
+commands. It does not initialize memory unless `--init` is passed.
+
+Useful installer options:
+
+```bash
+sh install.sh --help
+sh install.sh --project --init
+sh install.sh --global --install-dir "$HOME/.local"
+sh install.sh --no-animation
+```
+
+After install, rerun onboarding anytime:
+
+```bash
+tree-ring welcome
+tree-ring welcome --init
+```
+
+Open the terminal console after a global install:
+
+```bash
+tree-ring tui
+```
+
+Open the terminal console after a project-local install:
+
+```bash
+.tree-ring/bin/tree-ring --root .tree-ring tui
+```
 
 ## First Example
 
@@ -117,6 +164,14 @@ tree-ring tui
 tree-ring --root .tree-ring tui --event-stream ./tree-ring-events.jsonl --tick-ms 150
 ```
 
+From a source checkout without installing:
+
+```bash
+cargo run -p tree-ring-memory-cli -- --root .tree-ring welcome --init --no-animation
+cargo run -p tree-ring-memory-cli -- --root .tree-ring remember "Try the TUI with a first memory." --event-type lesson --scope project
+cargo run -p tree-ring-memory-cli -- --root .tree-ring tui
+```
+
 The console keeps an animated ASCII tree-ring cross-section visible at all
 times. Store-watch polling updates persisted counts from SQLite, while the
 optional event stream lights rings in real time without treating stream events
@@ -147,7 +202,9 @@ Event stream lines are local JSONL objects. They are display signals only:
 
 ```bash
 cargo test
+sh install.sh --help
 cargo run -p tree-ring-memory-cli -- --help
+cargo run -p tree-ring-memory-cli -- welcome --no-animation
 cargo run -p tree-ring-memory-cli -- tui --help
 cargo run -p tree-ring-memory-cli -- export --help
 cargo run -p tree-ring-memory-cli -- import --help
@@ -187,6 +244,8 @@ for the synthetic workload.
 - `docs/superpowers/plans/2026-07-05-tree-ring-memory-rust-only-v0-8-implementation-plan.md`
 - `docs/superpowers/specs/2026-07-05-tree-ring-memory-rust-only-repo-v0-9-design.md`
 - `docs/superpowers/plans/2026-07-05-tree-ring-memory-rust-only-repo-v0-9-implementation-plan.md`
+- `docs/superpowers/specs/2026-07-05-tree-ring-memory-installer-onboarding-v0-10-design.md`
+- `docs/superpowers/plans/2026-07-05-tree-ring-memory-installer-onboarding-v0-10-implementation-plan.md`
 
 ## Agent Workflow Integration
 

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "tree-ring-memory-native"
-version = "0.9.0"
+version = "0.10.0"
 description = "Native Rust bindings for Tree Ring Memory."
 requires-python = ">=3.11"
 license = { file = "../../LICENSE" }

--- a/crates/tree-ring-memory-cli/src/main.rs
+++ b/crates/tree-ring-memory-cli/src/main.rs
@@ -13,13 +13,27 @@ use tree_ring_memory_core::{
 use tree_ring_memory_sqlite::{MemoryRetriever, SQLiteMemoryStore};
 
 mod tui;
+mod welcome;
 
 #[derive(Debug, Parser)]
-#[command(name = "tree-ring", about = "Local tree-ring memory for AI agents.")]
+#[command(
+    name = "tree-ring",
+    version,
+    about = "Local tree-ring memory for AI agents."
+)]
 struct Cli {
-    #[arg(long, default_value = ".tree-ring", help = "memory store root")]
+    #[arg(
+        long,
+        default_value = ".tree-ring",
+        global = true,
+        help = "memory store root"
+    )]
     root: PathBuf,
-    #[arg(long, help = "emit machine-readable JSON where supported")]
+    #[arg(
+        long,
+        global = true,
+        help = "emit machine-readable JSON where supported"
+    )]
     json: bool,
     #[command(subcommand)]
     command: Command,
@@ -134,6 +148,13 @@ enum Command {
         )]
         tick_ms: u64,
     },
+    #[command(about = "show first-run onboarding and next commands")]
+    Welcome {
+        #[arg(long, help = "initialize the configured memory root during onboarding")]
+        init: bool,
+        #[arg(long, help = "print a stable onboarding screen without animation")]
+        no_animation: bool,
+    },
 }
 
 #[derive(Debug, Clone, clap::ValueEnum)]
@@ -154,6 +175,10 @@ fn main() -> std::process::ExitCode {
 
 fn run(cli: Cli) -> Result<(), String> {
     let db_path = cli.root.join("memory.sqlite");
+
+    if let Command::Welcome { init, no_animation } = &cli.command {
+        return welcome::run(&cli.root, *init, *no_animation, cli.json);
+    }
 
     if let Command::Tui {
         event_stream,
@@ -481,6 +506,9 @@ fn run(cli: Cli) -> Result<(), String> {
             print_maintenance_report(&report, cli.json)?;
         }
         Command::Tui { .. } => unreachable!("tui returns before opening the scriptable store"),
+        Command::Welcome { .. } => {
+            unreachable!("welcome returns before opening the scriptable store")
+        }
     }
     Ok(())
 }
@@ -1010,6 +1038,29 @@ mod tests {
                 assert_eq!(tick_ms, 125);
             }
             _ => panic!("expected tui command"),
+        }
+    }
+
+    #[test]
+    fn parses_global_flags_after_welcome_command() {
+        let cli = Cli::try_parse_from([
+            "tree-ring",
+            "welcome",
+            "--json",
+            "--root",
+            ".memory",
+            "--init",
+        ])
+        .unwrap();
+
+        assert!(cli.json);
+        assert_eq!(cli.root, PathBuf::from(".memory"));
+        match cli.command {
+            Command::Welcome { init, no_animation } => {
+                assert!(init);
+                assert!(!no_animation);
+            }
+            _ => panic!("expected welcome command"),
         }
     }
 

--- a/crates/tree-ring-memory-cli/src/welcome.rs
+++ b/crates/tree-ring-memory-cli/src/welcome.rs
@@ -1,0 +1,167 @@
+use serde_json::json;
+use std::io::{self, IsTerminal, Write};
+use std::path::Path;
+use std::thread;
+use std::time::Duration;
+use tree_ring_memory_sqlite::SQLiteMemoryStore;
+
+const RESET: &str = "\x1b[0m";
+const TEAL: &str = "\x1b[38;5;37m";
+const PINK: &str = "\x1b[38;5;204m";
+const ORANGE: &str = "\x1b[38;5;208m";
+const YELLOW: &str = "\x1b[38;5;220m";
+const BLUE: &str = "\x1b[38;5;33m";
+const BOLD: &str = "\x1b[1m";
+
+pub fn run(root: &Path, init: bool, no_animation: bool, json_output: bool) -> Result<(), String> {
+    let db_path = root.join("memory.sqlite");
+    let initialized = if init {
+        SQLiteMemoryStore::open(&db_path).map_err(|err| err.to_string())?;
+        true
+    } else {
+        db_path.exists()
+    };
+
+    if json_output {
+        println!(
+            "{}",
+            json!({
+                "ok": true,
+                "root": root,
+                "sqlite_path": db_path,
+                "initialized": initialized,
+                "init_requested": init,
+                "next": next_commands(root),
+            })
+        );
+        return Ok(());
+    }
+
+    let color = io::stdout().is_terminal();
+    if color && !no_animation {
+        animate_intro()?;
+    }
+    print_static_welcome(root, initialized, init, color);
+    Ok(())
+}
+
+fn animate_intro() -> Result<(), String> {
+    let mut stdout = io::stdout();
+    for frame in 0..8 {
+        write!(stdout, "\x1b[2J\x1b[H").map_err(|err| err.to_string())?;
+        for line in ring_frame(frame, true) {
+            writeln!(stdout, "{line}").map_err(|err| err.to_string())?;
+        }
+        stdout.flush().map_err(|err| err.to_string())?;
+        thread::sleep(Duration::from_millis(90));
+    }
+    Ok(())
+}
+
+fn print_static_welcome(root: &Path, initialized: bool, init_requested: bool, color: bool) {
+    for line in ring_frame(7, color) {
+        println!("{line}");
+    }
+    println!();
+    println!("{}", paint("Tree Ring Memory is ready.", BOLD, color));
+    if initialized && init_requested {
+        println!(
+            "Project initialized at {}. Fresh memory can start in cambium.",
+            root.display()
+        );
+    } else if initialized {
+        println!(
+            "Memory root found at {}. You can recall or open the TUI now.",
+            root.display()
+        );
+    } else {
+        println!(
+            "No memory root yet at {}. Run init when you are ready.",
+            root.display()
+        );
+    }
+    println!("Local-first by default. Secret-like memory is blocked before storage.");
+    println!();
+    println!("{}", paint("Next useful commands", YELLOW, color));
+    for command in next_commands(root) {
+        println!("  {command}");
+    }
+}
+
+fn next_commands(root: &Path) -> Vec<String> {
+    vec![
+        format!("tree-ring --root {} init", shell_path(root)),
+        format!(
+            "tree-ring --root {} remember \"Use project-scoped recall before risky changes.\" --event-type lesson --scope project",
+            shell_path(root)
+        ),
+        format!("tree-ring --root {} tui", shell_path(root)),
+    ]
+}
+
+fn shell_path(path: &Path) -> String {
+    let value = path.display().to_string();
+    if value.contains(' ') {
+        format!("'{value}'")
+    } else {
+        value
+    }
+}
+
+fn ring_frame(frame: usize, color: bool) -> Vec<String> {
+    let pulse = if frame % 2 == 0 { "*" } else { "+" };
+    vec![
+        paint("        .-=================-.        ", TEAL, color) + pulse,
+        paint("     .-'   cambium  fresh   '-.     ", PINK, color),
+        paint("   .'   .--- outer  detailed ---.   '.", ORANGE, color),
+        paint("  /   .'   .-- inner  compressed --.  \\", YELLOW, color),
+        paint(" |   /   .' heartwood durable '.   | ", BLUE, color),
+        paint("  \\   '.   scars visible seeds   .'  /", PINK, color),
+        paint("   '.   '---.          .---'   .'   ", ORANGE, color),
+        paint("     '-.       '------'       .-'    ", TEAL, color),
+        paint("        '==================='        ", BLUE, color),
+    ]
+}
+
+fn paint(text: &str, color_code: &str, color: bool) -> String {
+    if color {
+        format!("{color_code}{text}{RESET}")
+    } else {
+        text.to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn next_commands_point_at_root_and_tui() {
+        let commands = next_commands(Path::new(".tree-ring"));
+
+        assert_eq!(commands.len(), 3);
+        assert!(commands[0].contains(" init"));
+        assert!(commands[2].contains(" tui"));
+    }
+
+    #[test]
+    fn no_animation_welcome_can_initialize_store() {
+        let dir = tempdir().unwrap();
+        let root = dir.path().join(".tree-ring");
+
+        run(&root, true, true, false).unwrap();
+
+        assert!(root.join("memory.sqlite").exists());
+    }
+
+    #[test]
+    fn json_welcome_can_initialize_store() {
+        let dir = tempdir().unwrap();
+        let root = dir.path().join(".tree-ring");
+
+        run(&root, true, true, true).unwrap();
+
+        assert!(root.join("memory.sqlite").exists());
+    }
+}

--- a/docs/architecture/rust-core-status.md
+++ b/docs/architecture/rust-core-status.md
@@ -5,8 +5,8 @@ runtime. This page tracks the v0.2 Rust
 core, v0.3 native Python binding work, the Rust-native Ratatui terminal
 console, the v0.4 Rust-owned JSONL import/export path, and v0.5 deterministic
 audit checks, the v0.6 deterministic consolidation path, the v0.7 Rust-owned
-maintenance lifecycle, v0.8 Python-runtime removal, and v0.9 removal of tracked
-Python source from the canonical repo.
+maintenance lifecycle, v0.8 Python-runtime removal, v0.9 removal of tracked
+Python source from the canonical repo, and v0.10 installer/onboarding work.
 
 ## Current Status
 
@@ -44,12 +44,16 @@ Python source from the canonical repo.
   always-visible animated ASCII tree-ring view, SQLite store-watch refresh,
   optional JSONL event-stream pulses, search/detail panes, and confirmation
   gates for destructive or authority-changing actions.
+- The repository includes `install.sh` for one-line global or project-local
+  installs, plus `tree-ring welcome` for first-run terminal onboarding.
 
 ## Build Commands
 
 ```bash
 cargo test
+sh install.sh --help
 cargo run -p tree-ring-memory-cli -- --help
+cargo run -p tree-ring-memory-cli -- welcome --no-animation
 cargo run -p tree-ring-memory-cli -- tui --help
 cargo run -p tree-ring-memory-cli -- export --help
 cargo run -p tree-ring-memory-cli -- import --help

--- a/docs/superpowers/plans/2026-07-05-tree-ring-memory-installer-onboarding-v0-10-implementation-plan.md
+++ b/docs/superpowers/plans/2026-07-05-tree-ring-memory-installer-onboarding-v0-10-implementation-plan.md
@@ -1,0 +1,73 @@
+# Tree Ring Memory Installer And Onboarding v0.10 Implementation Plan
+
+## Task 1: Add Rust Welcome Command
+
+Files:
+
+- `crates/tree-ring-memory-cli/src/main.rs`
+- `crates/tree-ring-memory-cli/src/welcome.rs`
+
+Work:
+
+- Add `tree-ring welcome`.
+- Add `--init` and `--no-animation` options.
+- Respect global `--root` and `--json`.
+- Print concise onboarding commands.
+- Initialize SQLite only when `--init` is present.
+- Add tests for no-animation output, init behavior, and JSON behavior.
+
+Checks:
+
+```bash
+cargo test -p tree-ring-memory-cli welcome
+cargo run -q -p tree-ring-memory-cli -- welcome --no-animation
+```
+
+## Task 2: Add Installer Script
+
+Files:
+
+- `install.sh`
+
+Work:
+
+- Implement POSIX shell installer.
+- Default to global install in `$HOME/.local`.
+- Add `--project`, `--init`, `--no-init`, `--no-animation`, `--install-dir`,
+  `--repo`, `--ref`, and `--source`.
+- Use `cargo install --path` for local source smoke and `cargo install --git`
+  for the curl path.
+- Run `tree-ring welcome` after successful install unless disabled.
+- Give clear recovery messages for missing cargo or failed install.
+
+Checks:
+
+```bash
+sh install.sh --help
+sh install.sh --source . --install-dir /tmp/tree-ring-install --no-animation --no-init
+```
+
+## Task 3: Update Docs And Verify
+
+Files:
+
+- `README.md`
+- `docs/architecture/rust-core-status.md`
+
+Work:
+
+- Add one-line install commands.
+- Add project-local install and init guidance.
+- Add TUI launch commands for installed and source-checkout paths.
+- Add installer checks to development commands.
+
+Final checks:
+
+```bash
+cargo test
+sh install.sh --help
+sh install.sh --source . --install-dir /tmp/tree-ring-install --no-animation --no-init
+cargo run -q -p tree-ring-memory-cli -- welcome --no-animation
+cargo run -q -p tree-ring-memory-cli -- --root /tmp/tree-ring-welcome welcome --init --no-animation
+git diff --check
+```

--- a/docs/superpowers/specs/2026-07-05-tree-ring-memory-installer-onboarding-v0-10-design.md
+++ b/docs/superpowers/specs/2026-07-05-tree-ring-memory-installer-onboarding-v0-10-design.md
@@ -1,0 +1,66 @@
+# Tree Ring Memory Installer And Onboarding v0.10 Design
+
+v0.10 adds a one-line installer and a terminal onboarding path that make Tree
+Ring Memory easy to try globally or inside a project.
+
+## Intent
+
+Tree Ring Memory should feel approachable without hiding that it is a serious
+local memory tool. The install flow should satisfy the basics first: it works,
+handles errors clearly, and leaves the user with obvious next commands. Delight
+comes from a short animated ASCII ring moment and useful guidance, not from a
+blocking wizard.
+
+## Goals
+
+- Provide a curl-friendly `install.sh`.
+- Support global install into `$HOME/.local/bin` by default.
+- Support project-local install into `.tree-ring/bin` with `--project`.
+- Support optional project initialization with `--init`.
+- Add a Rust-native `tree-ring welcome` command with terminal-safe ASCII rings.
+- Use animation only when stdout is a TTY and the user has not disabled it.
+- Keep non-interactive/scripted output deterministic with `--no-animation`.
+- Document how to install, initialize, and open the TUI.
+
+## Non-Goals
+
+- Do not require a package manager beyond an existing Rust toolchain.
+- Do not add shell dependencies beyond POSIX `sh` plus `cargo`.
+- Do not create cloud accounts or remote sync.
+- Do not initialize a project unless the user asks through `--init`.
+
+## Installer UX
+
+Default:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/TerminallyLazy/Tree-Ring-Memory/main/install.sh | sh
+```
+
+Project-local:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/TerminallyLazy/Tree-Ring-Memory/main/install.sh | sh -s -- --project --init
+```
+
+Emotional arc:
+
+- First encounter: clear retro tree-ring identity.
+- Setup: explain where the binary will go before building.
+- First success: confirm install and show the next three useful commands.
+- Recovery: explain missing Rust/cargo with a concrete fix.
+
+## Acceptance Criteria
+
+1. `install.sh --help` documents global, project, init, no-animation, local
+   source, and install-dir options.
+2. `install.sh --source . --install-dir <tmp> --no-animation --no-init` installs
+   a working `tree-ring` binary.
+3. `tree-ring welcome --no-animation` prints onboarding guidance without
+   opening SQLite.
+4. `tree-ring welcome --init --no-animation` initializes the configured root.
+5. `tree-ring welcome --json --init` emits a structured status payload.
+6. README includes one-line install, project-local install, and TUI launch
+   instructions.
+7. `cargo test` passes.
+8. `git diff --check` passes.

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,243 @@
+#!/bin/sh
+set -eu
+
+REPO_URL=${TREE_RING_REPO:-"https://github.com/TerminallyLazy/Tree-Ring-Memory"}
+GIT_REF=${TREE_RING_REF:-"main"}
+INSTALL_SCOPE=${TREE_RING_INSTALL_SCOPE:-"global"}
+INSTALL_DIR=${TREE_RING_INSTALL_DIR:-""}
+SOURCE_DIR=${TREE_RING_SOURCE:-""}
+MEMORY_ROOT=${TREE_RING_ROOT:-".tree-ring"}
+RUN_INIT=${TREE_RING_INIT:-"0"}
+RUN_ONBOARDING=${TREE_RING_ONBOARDING:-"1"}
+ANIMATION=${TREE_RING_ANIMATION:-"1"}
+
+if [ ! -t 1 ] || [ "${NO_COLOR:-}" != "" ]; then
+  COLOR=0
+else
+  COLOR=1
+fi
+
+die() {
+  printf '%s\n' "Tree Ring Memory install failed: $*" >&2
+  exit 1
+}
+
+usage() {
+  cat <<'EOF'
+Tree Ring Memory installer
+
+Usage:
+  curl -fsSL https://raw.githubusercontent.com/TerminallyLazy/Tree-Ring-Memory/main/install.sh | sh
+  curl -fsSL https://raw.githubusercontent.com/TerminallyLazy/Tree-Ring-Memory/main/install.sh | sh -s -- --project --init
+
+Options:
+  --global              Install to $HOME/.local/bin (default).
+  --project             Install to .tree-ring/bin in the current project.
+  --init                Run tree-ring welcome --init after install.
+  --no-init             Do not initialize memory after install (default).
+  --no-animation        Print stable output without animated rings.
+  --no-onboarding       Skip tree-ring welcome after install.
+  --install-dir DIR     Override install prefix. Binary goes in DIR/bin.
+  --root DIR            Memory root used by onboarding/init (default .tree-ring).
+  --repo URL            Git repository used by cargo install.
+  --ref REF             Git branch used by cargo install (default main).
+  --source DIR          Install from a local checkout instead of git.
+  -h, --help            Show this help.
+
+Environment:
+  TREE_RING_INSTALL_SCOPE=global|project
+  TREE_RING_INSTALL_DIR=/path/to/prefix
+  TREE_RING_ROOT=.tree-ring
+  TREE_RING_REPO=https://github.com/TerminallyLazy/Tree-Ring-Memory
+  TREE_RING_REF=main
+  TREE_RING_SOURCE=/path/to/checkout
+  TREE_RING_INIT=1
+  TREE_RING_ANIMATION=0
+  TREE_RING_ONBOARDING=0
+EOF
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --global)
+      INSTALL_SCOPE=global
+      ;;
+    --project)
+      INSTALL_SCOPE=project
+      ;;
+    --init)
+      RUN_INIT=1
+      ;;
+    --no-init)
+      RUN_INIT=0
+      ;;
+    --no-animation)
+      ANIMATION=0
+      ;;
+    --no-onboarding)
+      RUN_ONBOARDING=0
+      ;;
+    --install-dir)
+      shift
+      [ "$#" -gt 0 ] || die "--install-dir requires a value"
+      INSTALL_DIR=$1
+      ;;
+    --root)
+      shift
+      [ "$#" -gt 0 ] || die "--root requires a value"
+      MEMORY_ROOT=$1
+      ;;
+    --repo)
+      shift
+      [ "$#" -gt 0 ] || die "--repo requires a value"
+      REPO_URL=$1
+      ;;
+    --ref)
+      shift
+      [ "$#" -gt 0 ] || die "--ref requires a value"
+      GIT_REF=$1
+      ;;
+    --source)
+      shift
+      [ "$#" -gt 0 ] || die "--source requires a value"
+      SOURCE_DIR=$1
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      die "unknown option: $1"
+      ;;
+  esac
+  shift
+done
+
+paint() {
+  code=$1
+  text=$2
+  if [ "$COLOR" = "1" ]; then
+    printf '\033[%sm%s\033[0m' "$code" "$text"
+  else
+    printf '%s' "$text"
+  fi
+}
+
+line() {
+  printf '%s\n' "$*"
+}
+
+ring_frame() {
+  pulse=$1
+  paint "38;5;37" "        .-=================-.        "
+  line "$pulse"
+  paint "38;5;204" "     .-'   cambium  fresh   '-.     "
+  line ""
+  paint "38;5;208" "   .'   .--- outer  detailed ---.   '."
+  line ""
+  paint "38;5;220" "  /   .'   .-- inner compressed --.  \\"
+  line ""
+  paint "38;5;33" " |   /   .' heartwood durable '.   | "
+  line ""
+  paint "38;5;204" "  \\   '.   scars visible seeds   .'  /"
+  line ""
+  paint "38;5;208" "   '.   '---.          .---'   .'   "
+  line ""
+  paint "38;5;37" "     '-.       '------'       .-'    "
+  line ""
+  paint "38;5;33" "        '==================='        "
+  line ""
+}
+
+intro() {
+  if [ "$ANIMATION" = "1" ] && [ "$COLOR" = "1" ]; then
+    for pulse in "*" "+" "*" "+"; do
+      printf '\033[2J\033[H'
+      ring_frame "$pulse"
+      sleep 0.08
+    done
+  else
+    ring_frame "*"
+  fi
+  line ""
+  paint "1" "Tree Ring Memory"
+  line " installer"
+  line "Framework-agnostic local memory for AI agents."
+  line ""
+}
+
+require_cargo() {
+  if ! command -v cargo >/dev/null 2>&1; then
+    die "cargo was not found. Install Rust from https://rustup.rs, then rerun this installer."
+  fi
+}
+
+install_prefix() {
+  if [ "$INSTALL_DIR" != "" ]; then
+    printf '%s' "$INSTALL_DIR"
+    return
+  fi
+  if [ "$INSTALL_SCOPE" = "project" ]; then
+    printf '%s' ".tree-ring"
+  else
+    printf '%s' "$HOME/.local"
+  fi
+}
+
+install_binary() {
+  prefix=$1
+  mkdir -p "$prefix"
+  line "Installing tree-ring into $prefix/bin"
+  line "Setting things up. This usually takes about 30 seconds after dependencies are cached."
+  if [ "$SOURCE_DIR" != "" ]; then
+    cargo install --path "$SOURCE_DIR/crates/tree-ring-memory-cli" --root "$prefix" --locked --force
+  else
+    cargo install --git "$REPO_URL" --branch "$GIT_REF" --package tree-ring-memory-cli --root "$prefix" --locked --force
+  fi
+}
+
+path_contains() {
+  case ":$PATH:" in
+    *":$1:"*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+intro
+require_cargo
+
+PREFIX=$(install_prefix)
+BIN="$PREFIX/bin/tree-ring"
+
+install_binary "$PREFIX"
+
+[ -x "$BIN" ] || die "expected installed binary at $BIN"
+"$BIN" --help >/dev/null || die "installed binary did not run"
+
+line ""
+paint "1" "Installed:"
+line " $BIN"
+
+if [ "$RUN_ONBOARDING" = "1" ]; then
+  WELCOME_FLAGS=""
+  if [ "$RUN_INIT" = "1" ]; then
+    WELCOME_FLAGS="$WELCOME_FLAGS --init"
+  fi
+  if [ "$ANIMATION" != "1" ]; then
+    WELCOME_FLAGS="$WELCOME_FLAGS --no-animation"
+  fi
+  # shellcheck disable=SC2086
+  "$BIN" --root "$MEMORY_ROOT" welcome $WELCOME_FLAGS
+fi
+
+line ""
+if [ "$INSTALL_SCOPE" = "global" ] && ! path_contains "$PREFIX/bin"; then
+  line "Add this to your shell profile if tree-ring is not found:"
+  line "  export PATH=\"$PREFIX/bin:\$PATH\""
+fi
+if [ "$INSTALL_SCOPE" = "project" ]; then
+  line "For project-local use:"
+  line "  export PATH=\"$PWD/$PREFIX/bin:\$PATH\""
+fi
+line "Open the TUI:"
+line "  $BIN --root $MEMORY_ROOT tui"


### PR DESCRIPTION
Summary:
- Add a POSIX one-line installer with global and project-local install modes.
- Add Rust-native `tree-ring welcome` onboarding with ASCII ring animation and JSON/no-animation modes.
- Apply the Tree Ring Memory retro palette to the Ratatui console as functional ring/status accents.
- Add non-destructive init scaffolding for agent awareness: `.tree-ring/AGENTS.md`, `.tree-ring/SKILL.md`, and `.tree-ring/CLI.md`.
- Add `tree-ring evidence` for the Revolve-inspired evidence loop: promoted -> heartwood, rejected -> scar, deferred -> seed, observed -> outer.
- Update README, integration docs, skill, and DOX template with install, onboarding, TUI, agent-awareness, and evidence-loop instructions.

Verification:
- sh -n install.sh: passed.
- sh install.sh --help: passed.
- cargo test -p tree-ring-memory-cli welcome: passed.
- cargo test: passed.
- cargo build -p tree-ring-memory-python --features extension-module: passed locally before initial PR creation.
- Project-local installer smoke using --source, --project, --init, --no-animation: passed locally.
- Real init smoke created memory.sqlite, AGENTS.md, SKILL.md, and CLI.md.
- Real evidence smoke stored promoted evidence as heartwood and recalled it by project.

Notes:
- Stacked on PR #13 / codex/rust-only-repo-v0.9.
- .vscode/ remains untracked and was not included.