### PR TITLE
Ship installer onboarding and evidence loop

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1759,7 +1759,7 @@ checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "tree-ring-memory-cli"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "clap",
  "ratatui",
@@ -1772,7 +1772,7 @@ dependencies = [
 
 [[package]]
 name = "tree-ring-memory-core"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "chrono",
  "once_cell",
@@ -1785,7 +1785,7 @@ dependencies = [
 
 [[package]]
 name = "tree-ring-memory-python"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "pyo3",
  "pyo3-build-config",
@@ -1798,7 +1798,7 @@ dependencies = [
 
 [[package]]
 name = "tree-ring-memory-sqlite"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "rusqlite",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.9.0"
+version = "0.10.0"
 edition = "2021"
 license = "MIT"
 authors = ["TerminallyLazy"]

--- a/README.md
+++ b/README.md
@@ -58,6 +58,19 @@ The installer builds the Rust CLI with `cargo`, installs `tree-ring`, then shows
 a short terminal onboarding screen with ASCII rings and the next useful
 commands. It does not initialize memory unless `--init` is passed.
 
+Initialization creates the SQLite store and non-destructive agent-awareness
+files in the memory root:
+
+- `.tree-ring/AGENTS.md`: DOX-style Tree Ring Memory guidance and root
+  `AGENTS.md` merge notes.
+- `.tree-ring/SKILL.md`: portable skill instructions for agent runtimes.
+- `.tree-ring/CLI.md`: quick command reference for recall, remember, forget,
+  maintain, and TUI usage.
+
+Existing awareness files are left untouched. Tree Ring Memory does not modify a
+project's root `AGENTS.md`; merge the generated guidance manually when you want
+DOX-aware agents to see it before entering `.tree-ring/`.
+
 Useful installer options:
 
 ```bash
@@ -106,6 +119,7 @@ The `tree-ring` command is the Rust CLI.
 ```bash
 tree-ring init
 tree-ring remember "Use protocol-first design." --event-type decision --tag architecture
+tree-ring evidence "Snapshot invalidation fixed stale unread chat state." --outcome promoted --evidence-ref evals/chat-state/run-042 --score 0.91
 tree-ring recall "protocol design"
 tree-ring forget mem_example --mode delete --reason "example cleanup"
 tree-ring export --output memories.jsonl
@@ -118,6 +132,35 @@ tree-ring maintain --apply-expired --repair-fts
 ```
 
 The CLI stores memory in `.tree-ring/` by default.
+
+## Evidence Loop
+
+The Revolve-inspired loop is exposed through `tree-ring evidence`. It records
+evaluated outcomes as memory with an evidence reference instead of treating
+claims as durable truth without support.
+
+```bash
+tree-ring evidence "Snapshot invalidation fixed stale unread chat state." \
+  --outcome promoted \
+  --evidence-ref evals/chat-state/run-042 \
+  --project agent-ui \
+  --score 0.91
+
+tree-ring evidence "Aggressive caching caused stale multi-chat state." \
+  --outcome rejected \
+  --evidence-ref evals/cache-branch/run-013 \
+  --project agent-ui
+```
+
+Outcome mapping:
+
+- `promoted` -> `heartwood`, durable `evaluation_promotion`
+- `rejected` -> `scar`, durable `evaluation_rejection`
+- `deferred` -> `seed`, `evaluation_hypothesis`
+- `observed` -> `outer`, `evaluation_result`
+
+This is not a replacement for Revolve records. Use source refs that point back
+to real evaluations, checkpoints, PRs, issues, logs, or run artifacts.
 
 `tree-ring export` writes newline-delimited JSON. The first line is a
 `tree_ring_memory_export` header with schema and plugin version metadata; each
@@ -252,6 +295,11 @@ for the synthetic workload.
 - `skills/tree-ring-memory/SKILL.md` gives agents portable guidance for when to recall, remember, redact, forget, or avoid memory capture.
 - `templates/dox/AGENTS.md` is a DOX-style project contract template for repos that want Tree Ring Memory rules alongside source code.
 - `docs/integrations/agent-skill.md` explains how to use both without making memory more authoritative than local project docs.
+- `tree-ring init` and `tree-ring welcome --init` copy local guidance into `.tree-ring/AGENTS.md`, `.tree-ring/SKILL.md`, and `.tree-ring/CLI.md` without overwriting existing files.
+
+For DOX-style project awareness, merge the relevant generated `.tree-ring/AGENTS.md`
+sections into the project root `AGENTS.md`. The CLI intentionally does not
+rewrite root project contracts automatically.
 
 ## Brand Assets
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Tree Ring Memory is in protocol-preview status.
 - v0.7 makes the public facade Rust-native only and adds Rust-owned maintenance for expiry, secret redaction, and FTS repair.
 - v0.8 removes Python-owned runtime behavior; Python is now a thin native-binding surface only.
 - v0.9 removes tracked Python source, tests, and smoke scripts from the canonical repo; the optional CPython extension is Rust-built.
+- v0.10 adds a one-line installer plus Rust-native terminal onboarding with ASCII tree rings.
 - The Rust CLI also includes a Ratatui operator console behind `tree-ring tui`.
 
 The Rust workspace currently includes:
@@ -38,6 +39,52 @@ The public runtime is Rust-native. The Rust CLI and Rust crates own storage,
 recall, import/export, audit, consolidation, maintenance, and terminal UI
 behavior. There is no tracked root Python package, Python wrapper layer, pytest
 suite, or Python smoke script.
+
+## Install
+
+Global user install:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/TerminallyLazy/Tree-Ring-Memory/main/install.sh | sh
+```
+
+Project-local install with first-run initialization:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/TerminallyLazy/Tree-Ring-Memory/main/install.sh | sh -s -- --project --init
+```
+
+The installer builds the Rust CLI with `cargo`, installs `tree-ring`, then shows
+a short terminal onboarding screen with ASCII rings and the next useful
+commands. It does not initialize memory unless `--init` is passed.
+
+Useful installer options:
+
+```bash
+sh install.sh --help
+sh install.sh --project --init
+sh install.sh --global --install-dir "$HOME/.local"
+sh install.sh --no-animation
+```
+
+After install, rerun onboarding anytime:
+
+```bash
+tree-ring welcome
+tree-ring welcome --init
+```
+
+Open the terminal console after a global install:
+
+```bash
+tree-ring tui
+```
+
+Open the terminal console after a project-local install:
+
+```bash
+.tree-ring/bin/tree-ring --root .tree-ring tui
+```
 
 ## First Example
 
@@ -117,6 +164,14 @@ tree-ring tui
 tree-ring --root .tree-ring tui --event-stream ./tree-ring-events.jsonl --tick-ms 150
 ```
 
+From a source checkout without installing:
+
+```bash
+cargo run -p tree-ring-memory-cli -- --root .tree-ring welcome --init --no-animation
+cargo run -p tree-ring-memory-cli -- --root .tree-ring remember "Try the TUI with a first memory." --event-type lesson --scope project
+cargo run -p tree-ring-memory-cli -- --root .tree-ring tui
+```
+
 The console keeps an animated ASCII tree-ring cross-section visible at all
 times. Store-watch polling updates persisted counts from SQLite, while the
 optional event stream lights rings in real time without treating stream events
@@ -147,7 +202,9 @@ Event stream lines are local JSONL objects. They are display signals only:
 
 ```bash
 cargo test
+sh install.sh --help
 cargo run -p tree-ring-memory-cli -- --help
+cargo run -p tree-ring-memory-cli -- welcome --no-animation
 cargo run -p tree-ring-memory-cli -- tui --help
 cargo run -p tree-ring-memory-cli -- export --help
 cargo run -p tree-ring-memory-cli -- import --help
@@ -187,6 +244,8 @@ for the synthetic workload.
 - `docs/superpowers/plans/2026-07-05-tree-ring-memory-rust-only-v0-8-implementation-plan.md`
 - `docs/superpowers/specs/2026-07-05-tree-ring-memory-rust-only-repo-v0-9-design.md`
 - `docs/superpowers/plans/2026-07-05-tree-ring-memory-rust-only-repo-v0-9-implementation-plan.md`
+- `docs/superpowers/specs/2026-07-05-tree-ring-memory-installer-onboarding-v0-10-design.md`
+- `docs/superpowers/plans/2026-07-05-tree-ring-memory-installer-onboarding-v0-10-implementation-plan.md`
 
 ## Agent Workflow Integration
 

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "tree-ring-memory-native"
-version = "0.9.0"
+version = "0.10.0"
 description = "Native Rust bindings for Tree Ring Memory."
 requires-python = ">=3.11"
 license = { file = "../../LICENSE" }

--- a/crates/tree-ring-memory-cli/src/agent_awareness.rs
+++ b/crates/tree-ring-memory-cli/src/agent_awareness.rs
@@ -1,0 +1,166 @@
+use serde::Serialize;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+const SKILL_TEMPLATE: &str = include_str!("../../../skills/tree-ring-memory/SKILL.md");
+const DOX_TEMPLATE: &str = include_str!("../../../templates/dox/AGENTS.md");
+const CLI_REFERENCE: &str = r#"# Tree Ring Memory CLI Quick Reference
+
+Tree Ring Memory is a local-first memory lifecycle layer for AI agents.
+
+Use memory deliberately:
+
+- recall before substantial project work
+- remember durable decisions, lessons, warnings, and user preferences
+- use scars for failures that should not be repeated
+- use seeds for future work and hypotheses
+- forget, redact, or supersede stale or sensitive memory
+
+Core commands:
+
+```bash
+tree-ring init
+tree-ring recall "project startup warnings"
+tree-ring remember "Use project-scoped recall before risky changes." --event-type lesson --scope project
+tree-ring evidence "Snapshot invalidation fixed stale unread chat state." --outcome promoted --evidence-ref evals/chat-state/run-042 --score 0.91
+tree-ring evidence "Aggressive caching caused stale multi-chat state." --outcome rejected --evidence-ref evals/cache-branch/run-013
+tree-ring forget mem_example --mode redact --reason "remove sensitive detail"
+tree-ring consolidate --period-type manual --dry-run
+tree-ring maintain
+tree-ring tui
+```
+
+Safety rules:
+
+- Do not store secrets, credentials, private keys, or raw chain-of-thought.
+- Prefer concise, source-linked summaries over transcript capture.
+- Treat local source files, tests, explicit user instructions, and root `AGENTS.md` files as authoritative.
+- When memory and source docs disagree, re-read source docs and update or forget stale memory.
+"#;
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct AgentAwarenessReport {
+    pub created: Vec<PathBuf>,
+    pub existing: Vec<PathBuf>,
+}
+
+pub fn ensure_agent_awareness(root: &Path) -> Result<AgentAwarenessReport, String> {
+    fs::create_dir_all(root).map_err(|err| err.to_string())?;
+    let mut report = AgentAwarenessReport {
+        created: Vec::new(),
+        existing: Vec::new(),
+    };
+
+    write_if_missing(&root.join("AGENTS.md"), &agent_contract(root), &mut report)?;
+    write_if_missing(&root.join("SKILL.md"), SKILL_TEMPLATE, &mut report)?;
+    write_if_missing(&root.join("CLI.md"), CLI_REFERENCE, &mut report)?;
+
+    Ok(report)
+}
+
+fn write_if_missing(
+    path: &Path,
+    content: &str,
+    report: &mut AgentAwarenessReport,
+) -> Result<(), String> {
+    if path.exists() {
+        report.existing.push(path.to_path_buf());
+        return Ok(());
+    }
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).map_err(|err| err.to_string())?;
+    }
+    fs::write(path, content).map_err(|err| err.to_string())?;
+    report.created.push(path.to_path_buf());
+    Ok(())
+}
+
+fn agent_contract(root: &Path) -> String {
+    format!(
+        r#"# Tree Ring Memory Agent Instructions
+
+This directory contains Tree Ring Memory's local project memory store.
+
+Memory is a recall aid. It does not replace project source files, tests, root
+`AGENTS.md` files, explicit user instructions, DOX contracts, or other local
+project documentation.
+
+## Memory Root
+
+```text
+{root}
+```
+
+Do not commit local memory databases or exports unless the project explicitly
+requires sanitized fixtures.
+
+## Agent Skill
+
+Read `SKILL.md` before using Tree Ring Memory. It explains when to recall,
+remember, redact, forget, consolidate, and avoid memory capture.
+
+## CLI Reference
+
+Read `CLI.md` for local commands. Common commands:
+
+```bash
+tree-ring --root {root} recall "project startup warnings"
+tree-ring --root {root} remember "Use project-scoped recall before risky changes." --event-type lesson --scope project
+tree-ring --root {root} forget mem_example --mode redact --reason "remove sensitive detail"
+tree-ring --root {root} tui
+```
+
+## DOX Integration
+
+If this project uses DOX-style `AGENTS.md` traversal, merge the relevant
+sections from the template below into the project root `AGENTS.md`. Tree Ring
+Memory does not overwrite root project contracts automatically.
+
+---
+
+{DOX_TEMPLATE}
+"#,
+        root = shell_path(root)
+    )
+}
+
+fn shell_path(path: &Path) -> String {
+    path.display().to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn init_writes_agent_awareness_files_without_overwriting() {
+        let dir = tempdir().unwrap();
+        let root = dir.path().join(".tree-ring");
+
+        let first = ensure_agent_awareness(&root).unwrap();
+        assert_eq!(first.created.len(), 3);
+        assert!(root.join("AGENTS.md").exists());
+        assert!(root.join("SKILL.md").exists());
+        assert!(root.join("CLI.md").exists());
+
+        fs::write(root.join("CLI.md"), "custom").unwrap();
+        let second = ensure_agent_awareness(&root).unwrap();
+        assert!(second.existing.iter().any(|path| path.ends_with("CLI.md")));
+        assert_eq!(fs::read_to_string(root.join("CLI.md")).unwrap(), "custom");
+    }
+
+    #[test]
+    fn generated_agents_file_mentions_skill_cli_and_dox() {
+        let dir = tempdir().unwrap();
+        let root = dir.path().join(".tree-ring");
+
+        ensure_agent_awareness(&root).unwrap();
+        let agents = fs::read_to_string(root.join("AGENTS.md")).unwrap();
+
+        assert!(agents.contains("SKILL.md"));
+        assert!(agents.contains("CLI.md"));
+        assert!(agents.contains("DOX Integration"));
+        assert!(agents.contains("Tree Ring Memory Project Contract"));
+    }
+}

--- a/crates/tree-ring-memory-cli/src/agent_awareness.rs
+++ b/crates/tree-ring-memory-cli/src/agent_awareness.rs
@@ -125,7 +125,12 @@ Memory does not overwrite root project contracts automatically.
 }
 
 fn shell_path(path: &Path) -> String {
-    path.display().to_string()
+    let value = path.display().to_string();
+    if value.contains(' ') {
+        format!("'{value}'")
+    } else {
+        value
+    }
 }
 
 #[cfg(test)]
@@ -162,5 +167,16 @@ mod tests {
         assert!(agents.contains("CLI.md"));
         assert!(agents.contains("DOX Integration"));
         assert!(agents.contains("Tree Ring Memory Project Contract"));
+    }
+
+    #[test]
+    fn generated_agents_file_quotes_roots_with_spaces() {
+        let dir = tempdir().unwrap();
+        let root = dir.path().join("project memory").join(".tree-ring");
+
+        ensure_agent_awareness(&root).unwrap();
+        let agents = fs::read_to_string(root.join("AGENTS.md")).unwrap();
+
+        assert!(agents.contains(&format!("--root '{}'", root.display())));
     }
 }

--- a/crates/tree-ring-memory-cli/src/main.rs
+++ b/crates/tree-ring-memory-cli/src/main.rs
@@ -4,14 +4,15 @@ use std::fs;
 use std::path::PathBuf;
 use tree_ring_memory_core::plan_maintenance;
 use tree_ring_memory_core::sensitivity::SensitivityGuard;
-use tree_ring_memory_core::MemoryEvent;
 use tree_ring_memory_core::{
     audit_memories, consolidate_memories, decode_jsonl, normalize_import_events, AuditReport,
     ConsolidationPeriod, ConsolidationReport, ConsolidationRequest, MaintenanceReport,
     MaintenanceRequest,
 };
+use tree_ring_memory_core::{MemoryEvent, MemoryLink};
 use tree_ring_memory_sqlite::{MemoryRetriever, SQLiteMemoryStore};
 
+mod agent_awareness;
 mod tui;
 mod welcome;
 
@@ -54,6 +55,29 @@ enum Command {
         scope: String,
         #[arg(long)]
         project: Option<String>,
+        #[arg(long = "tag")]
+        tags: Vec<String>,
+    },
+    #[command(about = "record an evidence-backed improvement-loop outcome")]
+    Evidence {
+        summary: String,
+        #[arg(
+            long,
+            default_value = "observed",
+            help = "observed, promoted, rejected, or deferred"
+        )]
+        outcome: String,
+        #[arg(
+            long,
+            help = "file path, run id, checkpoint id, PR, issue, or eval ref"
+        )]
+        evidence_ref: String,
+        #[arg(long, help = "optional project scope")]
+        project: Option<String>,
+        #[arg(long, help = "optional extra context")]
+        details: Option<String>,
+        #[arg(long, help = "optional numeric evaluation score")]
+        score: Option<f64>,
         #[arg(long = "tag")]
         tags: Vec<String>,
     },
@@ -293,6 +317,8 @@ fn run(cli: Cli) -> Result<(), String> {
 
     match cli.command {
         Command::Init => {
+            let awareness = agent_awareness::ensure_agent_awareness(&cli.root)
+                .map_err(|err| err.to_string())?;
             if cli.json {
                 println!(
                     "{}",
@@ -301,11 +327,13 @@ fn run(cli: Cli) -> Result<(), String> {
                         "root": cli.root,
                         "sqlite_path": db_path,
                         "message": "Tree Ring Memory initialized",
+                        "agent_awareness": awareness,
                     })
                 );
             } else {
                 println!("Tree Ring Memory initialized at {}", cli.root.display());
                 println!("No cloud sync; secret-like memory is blocked by default.");
+                print_agent_awareness_summary(&awareness);
             }
         }
         Command::Remember {
@@ -342,6 +370,37 @@ fn run(cli: Cli) -> Result<(), String> {
                 );
             } else {
                 println!("{}", event.id);
+            }
+        }
+        Command::Evidence {
+            summary,
+            outcome,
+            evidence_ref,
+            project,
+            details,
+            score,
+            tags,
+        } => {
+            let event = evidence_event(
+                summary,
+                outcome,
+                evidence_ref,
+                project,
+                details,
+                score,
+                tags,
+            )?;
+            store.put(&event).map_err(|err| err.to_string())?;
+            if cli.json {
+                println!(
+                    "{}",
+                    serde_json::to_string(&event).map_err(|err| err.to_string())?
+                );
+            } else {
+                println!(
+                    "{} [{}] {} evidence={}",
+                    event.id, event.ring, event.summary, event.source.ref_
+                );
             }
         }
         Command::Recall {
@@ -546,6 +605,120 @@ fn consolidation_request(
     })
 }
 
+fn evidence_event(
+    summary: String,
+    outcome: String,
+    evidence_ref: String,
+    project: Option<String>,
+    details: Option<String>,
+    score: Option<f64>,
+    tags: Vec<String>,
+) -> Result<MemoryEvent, String> {
+    if summary.trim().is_empty() {
+        return Err("evidence summary is required".to_string());
+    }
+    if evidence_ref.trim().is_empty() {
+        return Err("evidence-ref is required".to_string());
+    }
+    if let Some(score) = score {
+        if !(0.0..=1.0).contains(&score) {
+            return Err("evidence score must be between 0 and 1".to_string());
+        }
+    }
+
+    let normalized_outcome = outcome.trim().to_ascii_lowercase();
+    let (ring, event_type, salience, confidence, retention) = match normalized_outcome.as_str() {
+        "promoted" | "promotion" => (
+            "heartwood",
+            "evaluation_promotion",
+            0.86,
+            score.unwrap_or(0.84).max(0.75),
+            "durable",
+        ),
+        "rejected" | "rejection" => (
+            "scar",
+            "evaluation_rejection",
+            0.90,
+            score.unwrap_or(0.78),
+            "durable",
+        ),
+        "deferred" | "seed" | "hypothesis" => (
+            "seed",
+            "evaluation_hypothesis",
+            0.68,
+            score.unwrap_or(0.60),
+            "normal",
+        ),
+        "observed" | "observation" | "result" => (
+            "outer",
+            "evaluation_result",
+            0.72,
+            score.unwrap_or(0.70),
+            "normal",
+        ),
+        _ => {
+            return Err(
+                "evidence outcome must be observed, promoted, rejected, or deferred".to_string(),
+            )
+        }
+    };
+
+    let guard = SensitivityGuard::default();
+    let values = [&summary, &outcome, &evidence_ref]
+        .into_iter()
+        .chain(project.iter())
+        .chain(details.iter())
+        .chain(tags.iter())
+        .map(String::as_str);
+    let detected_sensitivity = guard
+        .detect_text_sensitivity(values)
+        .map_err(|err| err.to_string())?;
+
+    let mut event = MemoryEvent::new(summary.trim(), event_type).map_err(|err| err.to_string())?;
+    event.ring = ring.to_string();
+    event.scope = "eval".to_string();
+    event.project = project;
+    event.details = evidence_details(&normalized_outcome, score, details);
+    event.source.source_type = "evidence".to_string();
+    event.source.ref_ = evidence_ref.trim().to_string();
+    event.tags = evidence_tags(normalized_outcome.as_str(), tags);
+    event.salience = salience;
+    event.confidence = confidence.clamp(0.0, 1.0);
+    event.retention = retention.to_string();
+    event.links.push(MemoryLink {
+        link_type: "evidence".to_string(),
+        target: event.source.ref_.clone(),
+    });
+    if detected_sensitivity != "normal" {
+        event.sensitivity = detected_sensitivity;
+    }
+    event.validate().map_err(|err| err.to_string())?;
+    Ok(event)
+}
+
+fn evidence_details(outcome: &str, score: Option<f64>, details: Option<String>) -> String {
+    let mut lines = vec![format!("Outcome: {outcome}")];
+    if let Some(score) = score {
+        lines.push(format!("Score: {score:.3}"));
+    }
+    if let Some(details) = details {
+        let trimmed = details.trim();
+        if !trimmed.is_empty() {
+            lines.push(trimmed.to_string());
+        }
+    }
+    lines.join("\n")
+}
+
+fn evidence_tags(outcome: &str, mut tags: Vec<String>) -> Vec<String> {
+    tags.push("evidence".to_string());
+    tags.push("improvement-loop".to_string());
+    tags.push(format!("outcome:{outcome}"));
+    tags.sort();
+    tags.dedup();
+    tags
+}
+
 fn print_audit_report(report: &AuditReport, json_output: bool) -> Result<(), String> {
     if json_output {
         println!(
@@ -641,6 +814,22 @@ fn print_maintenance_report(report: &MaintenanceReport, json_output: bool) -> Re
     Ok(())
 }
 
+fn print_agent_awareness_summary(report: &agent_awareness::AgentAwarenessReport) {
+    if !report.created.is_empty() {
+        println!("Agent awareness files created:");
+        for path in &report.created {
+            println!("  {}", path.display());
+        }
+    }
+    if !report.existing.is_empty() {
+        println!("Agent awareness files already present:");
+        for path in &report.existing {
+            println!("  {}", path.display());
+        }
+    }
+    println!("If this repo uses DOX, merge .tree-ring/AGENTS.md guidance into the project root AGENTS.md when you want agents to see it before entering .tree-ring.");
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -658,6 +847,9 @@ mod tests {
         .unwrap();
 
         assert!(root.join("memory.sqlite").exists());
+        assert!(root.join("AGENTS.md").exists());
+        assert!(root.join("SKILL.md").exists());
+        assert!(root.join("CLI.md").exists());
     }
 
     #[test]
@@ -721,6 +913,88 @@ mod tests {
             },
         })
         .unwrap();
+    }
+
+    #[test]
+    fn evidence_promotion_becomes_heartwood_with_evidence_source() {
+        let dir = tempdir().unwrap();
+        let root = dir.path().join(".tree-ring");
+
+        run(Cli {
+            root: root.clone(),
+            json: false,
+            command: Command::Evidence {
+                summary: "Snapshot invalidation fixed stale unread chat state.".to_string(),
+                outcome: "promoted".to_string(),
+                evidence_ref: "evals/chat-state/run-042".to_string(),
+                project: Some("agent-ui".to_string()),
+                details: Some("Passed regression suite and manual replay.".to_string()),
+                score: Some(0.91),
+                tags: vec!["chat".to_string()],
+            },
+        })
+        .unwrap();
+
+        let store = SQLiteMemoryStore::open(root.join("memory.sqlite")).unwrap();
+        let memories = store.list_all(false).unwrap();
+        assert_eq!(memories.len(), 1);
+        let memory = &memories[0];
+        assert_eq!(memory.ring, "heartwood");
+        assert_eq!(memory.scope, "eval");
+        assert_eq!(memory.event_type, "evaluation_promotion");
+        assert_eq!(memory.retention, "durable");
+        assert_eq!(memory.source.source_type, "evidence");
+        assert_eq!(memory.source.ref_, "evals/chat-state/run-042");
+        assert!(memory.tags.contains(&"improvement-loop".to_string()));
+        assert!(memory.tags.contains(&"outcome:promoted".to_string()));
+    }
+
+    #[test]
+    fn evidence_rejection_becomes_scar() {
+        let dir = tempdir().unwrap();
+        let root = dir.path().join(".tree-ring");
+
+        run(Cli {
+            root: root.clone(),
+            json: false,
+            command: Command::Evidence {
+                summary: "Aggressive caching caused stale multi-chat state.".to_string(),
+                outcome: "rejected".to_string(),
+                evidence_ref: "evals/cache-branch/run-013".to_string(),
+                project: Some("agent-ui".to_string()),
+                details: None,
+                score: Some(0.82),
+                tags: Vec::new(),
+            },
+        })
+        .unwrap();
+
+        let store = SQLiteMemoryStore::open(root.join("memory.sqlite")).unwrap();
+        let memories = store.list_all(false).unwrap();
+        assert_eq!(memories[0].ring, "scar");
+        assert_eq!(memories[0].event_type, "evaluation_rejection");
+        assert_eq!(memories[0].retention, "durable");
+    }
+
+    #[test]
+    fn evidence_rejects_invalid_scores() {
+        let dir = tempdir().unwrap();
+        let err = run(Cli {
+            root: dir.path().join(".tree-ring"),
+            json: false,
+            command: Command::Evidence {
+                summary: "Invalid evidence score".to_string(),
+                outcome: "observed".to_string(),
+                evidence_ref: "evals/run".to_string(),
+                project: None,
+                details: None,
+                score: Some(2.0),
+                tags: Vec::new(),
+            },
+        })
+        .unwrap_err();
+
+        assert_eq!(err, "evidence score must be between 0 and 1");
     }
 
     #[test]

--- a/crates/tree-ring-memory-cli/src/main.rs
+++ b/crates/tree-ring-memory-cli/src/main.rs
@@ -13,13 +13,27 @@ use tree_ring_memory_core::{
 use tree_ring_memory_sqlite::{MemoryRetriever, SQLiteMemoryStore};
 
 mod tui;
+mod welcome;
 
 #[derive(Debug, Parser)]
-#[command(name = "tree-ring", about = "Local tree-ring memory for AI agents.")]
+#[command(
+    name = "tree-ring",
+    version,
+    about = "Local tree-ring memory for AI agents."
+)]
 struct Cli {
-    #[arg(long, default_value = ".tree-ring", help = "memory store root")]
+    #[arg(
+        long,
+        default_value = ".tree-ring",
+        global = true,
+        help = "memory store root"
+    )]
     root: PathBuf,
-    #[arg(long, help = "emit machine-readable JSON where supported")]
+    #[arg(
+        long,
+        global = true,
+        help = "emit machine-readable JSON where supported"
+    )]
     json: bool,
     #[command(subcommand)]
     command: Command,
@@ -134,6 +148,13 @@ enum Command {
         )]
         tick_ms: u64,
     },
+    #[command(about = "show first-run onboarding and next commands")]
+    Welcome {
+        #[arg(long, help = "initialize the configured memory root during onboarding")]
+        init: bool,
+        #[arg(long, help = "print a stable onboarding screen without animation")]
+        no_animation: bool,
+    },
 }
 
 #[derive(Debug, Clone, clap::ValueEnum)]
@@ -154,6 +175,10 @@ fn main() -> std::process::ExitCode {
 
 fn run(cli: Cli) -> Result<(), String> {
     let db_path = cli.root.join("memory.sqlite");
+
+    if let Command::Welcome { init, no_animation } = &cli.command {
+        return welcome::run(&cli.root, *init, *no_animation, cli.json);
+    }
 
     if let Command::Tui {
         event_stream,
@@ -481,6 +506,9 @@ fn run(cli: Cli) -> Result<(), String> {
             print_maintenance_report(&report, cli.json)?;
         }
         Command::Tui { .. } => unreachable!("tui returns before opening the scriptable store"),
+        Command::Welcome { .. } => {
+            unreachable!("welcome returns before opening the scriptable store")
+        }
     }
     Ok(())
 }
@@ -1010,6 +1038,29 @@ mod tests {
                 assert_eq!(tick_ms, 125);
             }
             _ => panic!("expected tui command"),
+        }
+    }
+
+    #[test]
+    fn parses_global_flags_after_welcome_command() {
+        let cli = Cli::try_parse_from([
+            "tree-ring",
+            "welcome",
+            "--json",
+            "--root",
+            ".memory",
+            "--init",
+        ])
+        .unwrap();
+
+        assert!(cli.json);
+        assert_eq!(cli.root, PathBuf::from(".memory"));
+        match cli.command {
+            Command::Welcome { init, no_animation } => {
+                assert!(init);
+                assert!(!no_animation);
+            }
+            _ => panic!("expected welcome command"),
         }
     }
 

--- a/crates/tree-ring-memory-cli/src/tui/mod.rs
+++ b/crates/tree-ring-memory-cli/src/tui/mod.rs
@@ -7,6 +7,7 @@ mod render;
 mod rings;
 mod store_watch;
 mod stream;
+mod theme;
 
 use std::path::PathBuf;
 use std::time::Duration;

--- a/crates/tree-ring-memory-cli/src/tui/render.rs
+++ b/crates/tree-ring-memory-cli/src/tui/render.rs
@@ -1,12 +1,13 @@
 use ratatui::layout::{Constraint, Direction, Layout, Rect};
-use ratatui::style::{Color, Modifier, Style};
+use ratatui::style::{Modifier, Style};
 use ratatui::text::{Line, Span};
-use ratatui::widgets::{Block, Borders, List, ListItem, Paragraph, Wrap};
+use ratatui::widgets::{List, ListItem, Paragraph, Wrap};
 use ratatui::Frame;
 
 use super::app::{App, AppMode};
 use super::input::command_help;
 use super::rings::{ambient_tree_lines, exploded_ring_lines, ring_style};
+use super::theme;
 
 pub fn render(frame: &mut Frame<'_>, app: &App) {
     let area = frame.area();
@@ -47,18 +48,21 @@ fn render_header(frame: &mut Frame<'_>, area: Rect, app: &App) {
         AppMode::Watch => "watch",
     };
     let header = Paragraph::new(Line::from(vec![
+        Span::styled("TREE RING MEMORY", theme::brand()),
+        Span::styled(format!("  mode:{mode}"), theme::accent()),
+        Span::styled(format!("  total:{}", app.dashboard.total), theme::title()),
         Span::styled(
-            "TREE RING MEMORY",
-            Style::default()
-                .fg(Color::LightYellow)
-                .add_modifier(Modifier::BOLD),
+            format!("  private:{}", app.dashboard.sensitive_total),
+            if app.dashboard.sensitive_total > 0 {
+                theme::warning()
+            } else {
+                theme::dim()
+            },
         ),
-        Span::raw(format!("  mode:{mode}")),
-        Span::raw(format!("  total:{}", app.dashboard.total)),
-        Span::raw(format!("  private:{}", app.dashboard.sensitive_total)),
-        Span::raw(format!("  status: {}", app.status)),
+        Span::styled("  status: ", theme::dim()),
+        Span::raw(app.status.clone()),
     ]))
-    .block(Block::default().borders(Borders::ALL));
+    .block(theme::plain_panel());
     frame.render_widget(header, area);
 }
 
@@ -88,18 +92,14 @@ fn render_body(frame: &mut Frame<'_>, area: Rect, app: &App) {
 
 fn render_ambient(frame: &mut Frame<'_>, area: Rect, app: &App) {
     let paragraph = Paragraph::new(ambient_tree_lines(&app.dashboard, app.tick))
-        .block(
-            Block::default()
-                .title("Ambient Rings")
-                .borders(Borders::ALL),
-        )
+        .block(theme::panel("Ambient Rings"))
         .wrap(Wrap { trim: false });
     frame.render_widget(paragraph, area);
 }
 
 fn render_exploded(frame: &mut Frame<'_>, area: Rect, app: &App) {
     let paragraph = Paragraph::new(exploded_ring_lines(&app.dashboard, app.selected_ring))
-        .block(Block::default().title("/rings").borders(Borders::ALL))
+        .block(theme::panel("/rings"))
         .wrap(Wrap { trim: false });
     frame.render_widget(paragraph, area);
 }
@@ -112,21 +112,34 @@ fn render_ring_hud(frame: &mut Frame<'_>, area: Rect, app: &App) {
         .enumerate()
         .map(|(index, stats)| {
             let selected = if index == app.selected_ring { ">" } else { " " };
+            let selector_style = if index == app.selected_ring {
+                theme::secondary_accent().add_modifier(Modifier::BOLD)
+            } else {
+                theme::dim()
+            };
             let line = Line::from(vec![
-                Span::raw(selected),
+                Span::styled(selected, selector_style),
                 Span::styled(format!(" {:<10}", stats.ring), ring_style(stats)),
-                Span::raw(format!(
-                    " {:>4} avg {:.2}/{:.2} private {}",
-                    stats.total,
-                    stats.average_confidence,
-                    stats.average_salience,
-                    stats.sensitive_count
-                )),
+                Span::styled(
+                    format!(" {:>4}", stats.total),
+                    if index == app.selected_ring {
+                        theme::selected()
+                    } else {
+                        theme::title()
+                    },
+                ),
+                Span::styled(
+                    format!(
+                        " avg {:.2}/{:.2} private {}",
+                        stats.average_confidence, stats.average_salience, stats.sensitive_count
+                    ),
+                    theme::dim(),
+                ),
             ]);
             ListItem::new(line)
         })
         .collect();
-    let list = List::new(items).block(Block::default().title("Rings").borders(Borders::ALL));
+    let list = List::new(items).block(theme::panel("Rings"));
     frame.render_widget(list, area);
 }
 
@@ -154,7 +167,7 @@ fn render_results(frame: &mut Frame<'_>, area: Rect, app: &App) {
     } else if app.results.is_empty() {
         vec![ListItem::new(Line::from(Span::styled(
             "No matching memory.",
-            Style::default().fg(Color::DarkGray),
+            theme::dim(),
         )))]
     } else {
         app.results
@@ -171,7 +184,7 @@ fn render_results(frame: &mut Frame<'_>, area: Rect, app: &App) {
             })
             .collect()
     };
-    let list = List::new(items).block(Block::default().title(title).borders(Borders::ALL));
+    let list = List::new(items).block(theme::panel(title));
     frame.render_widget(list, area);
 }
 
@@ -186,11 +199,29 @@ fn memory_item<'a>(
     let score = score
         .map(|score| format!(" score={score:.3}"))
         .unwrap_or_default();
+    let selected_row = index == selected;
+    let memory_style = if selected_row {
+        theme::selected()
+    } else {
+        Style::default()
+    };
     ListItem::new(Line::from(vec![
-        Span::raw(marker.to_string()),
-        Span::styled(format!(" [{ring}] "), Style::default().fg(Color::LightCyan)),
-        Span::raw(truncate(summary, 80)),
-        Span::styled(score, Style::default().fg(Color::DarkGray)),
+        Span::styled(
+            marker.to_string(),
+            if selected_row {
+                theme::secondary_accent().add_modifier(Modifier::BOLD)
+            } else {
+                theme::dim()
+            },
+        ),
+        Span::styled(
+            format!(" [{ring}] "),
+            Style::default()
+                .fg(theme::ring_color(ring, 0.0))
+                .add_modifier(Modifier::BOLD),
+        ),
+        Span::styled(truncate(summary, 80), memory_style),
+        Span::styled(score, theme::dim()),
     ]))
 }
 
@@ -203,23 +234,28 @@ fn render_detail(frame: &mut Frame<'_>, area: Rect, app: &App) {
             "[sensitive details hidden]".to_string()
         };
         lines.push(Line::from(vec![
-            Span::styled("id ", Style::default().fg(Color::DarkGray)),
+            Span::styled("id ", theme::dim()),
             Span::raw(memory.id.clone()),
         ]));
         lines.push(Line::from(vec![
-            Span::styled("ring ", Style::default().fg(Color::DarkGray)),
-            Span::raw(memory.ring.clone()),
-            Span::styled(" type ", Style::default().fg(Color::DarkGray)),
+            Span::styled("ring ", theme::dim()),
+            Span::styled(
+                memory.ring.clone(),
+                Style::default()
+                    .fg(theme::ring_color(&memory.ring, 0.0))
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::styled(" type ", theme::dim()),
             Span::raw(memory.event_type.clone()),
         ]));
         lines.push(Line::from(vec![
-            Span::styled("confidence ", Style::default().fg(Color::DarkGray)),
-            Span::raw(format!("{:.2}", memory.confidence)),
-            Span::styled(" salience ", Style::default().fg(Color::DarkGray)),
-            Span::raw(format!("{:.2}", memory.salience)),
+            Span::styled("confidence ", theme::dim()),
+            Span::styled(format!("{:.2}", memory.confidence), theme::accent()),
+            Span::styled(" salience ", theme::dim()),
+            Span::styled(format!("{:.2}", memory.salience), theme::secondary_accent()),
         ]));
         lines.push(Line::from(vec![
-            Span::styled("source ", Style::default().fg(Color::DarkGray)),
+            Span::styled("source ", theme::dim()),
             Span::raw(format!(
                 "{} {}",
                 memory.source.source_type, memory.source.ref_
@@ -239,40 +275,36 @@ fn render_detail(frame: &mut Frame<'_>, area: Rect, app: &App) {
     if app.mode == AppMode::Command {
         lines.push(Line::from(""));
         lines.push(Line::from(vec![
-            Span::styled("/", Style::default().fg(Color::LightYellow)),
+            Span::styled("/", theme::brand()),
             Span::raw(app.command_buffer.clone()),
         ]));
     } else if app.mode == AppMode::Search {
         lines.push(Line::from(""));
         lines.push(Line::from(vec![
-            Span::styled("search ", Style::default().fg(Color::LightYellow)),
+            Span::styled("search ", theme::brand()),
             Span::raw(app.search_query.clone()),
         ]));
     }
 
     if !app.live_events.is_empty() {
         lines.push(Line::from(""));
-        lines.push(Line::from(Span::styled(
-            "live",
-            Style::default()
-                .fg(Color::LightMagenta)
-                .add_modifier(Modifier::BOLD),
-        )));
+        lines.push(Line::from(Span::styled("live", theme::live())));
         for event in app.live_events.iter().rev().take(3) {
-            lines.push(Line::from(format!(
-                "{} {}",
-                event.ring.as_deref().unwrap_or("-"),
-                event.safe_label()
-            )));
+            let ring = event.ring.as_deref().unwrap_or("-");
+            lines.push(Line::from(vec![
+                Span::styled(
+                    format!("{ring:<10} "),
+                    Style::default()
+                        .fg(theme::ring_color(ring, 0.0))
+                        .add_modifier(Modifier::BOLD),
+                ),
+                Span::raw(event.safe_label()),
+            ]));
         }
     }
 
     let paragraph = Paragraph::new(lines)
-        .block(
-            Block::default()
-                .title("Detail / Actions")
-                .borders(Borders::ALL),
-        )
+        .block(theme::panel("Detail / Actions"))
         .wrap(Wrap { trim: true });
     frame.render_widget(paragraph, area);
 }
@@ -285,7 +317,8 @@ fn render_footer(frame: &mut Frame<'_>, area: Rect, app: &App) {
         command_help()
     );
     let footer = Paragraph::new(text)
-        .block(Block::default().title("Actions").borders(Borders::ALL))
+        .style(theme::accent())
+        .block(theme::panel("Actions"))
         .wrap(Wrap { trim: true });
     frame.render_widget(footer, area);
 }
@@ -295,32 +328,25 @@ fn render_confirmation(frame: &mut Frame<'_>, area: Rect, prompt: &str) {
     let paragraph = Paragraph::new(vec![
         Line::from(Span::styled(
             "Confirm Tree Ring Memory action",
-            Style::default()
-                .fg(Color::LightRed)
-                .add_modifier(Modifier::BOLD),
+            theme::warning(),
         )),
         Line::from(""),
         Line::from(prompt.to_string()),
     ])
-    .block(Block::default().borders(Borders::ALL))
+    .block(theme::plain_panel().border_style(theme::warning()))
     .wrap(Wrap { trim: true });
     frame.render_widget(paragraph, area);
 }
 
 fn render_compact(frame: &mut Frame<'_>, area: Rect, app: &App) {
-    let mut lines = vec![Line::from(Span::styled(
-        "TREE RING MEMORY",
-        Style::default()
-            .fg(Color::LightYellow)
-            .add_modifier(Modifier::BOLD),
-    ))];
+    let mut lines = vec![Line::from(Span::styled("TREE RING MEMORY", theme::brand()))];
     lines.extend(ambient_tree_lines(&app.dashboard, app.tick));
     lines.push(Line::from(format!(
         "total {} | q quit | / command",
         app.dashboard.total
     )));
     let paragraph = Paragraph::new(lines)
-        .block(Block::default().borders(Borders::ALL))
+        .block(theme::plain_panel())
         .wrap(Wrap { trim: false });
     frame.render_widget(paragraph, area);
 }

--- a/crates/tree-ring-memory-cli/src/tui/rings.rs
+++ b/crates/tree-ring-memory-cli/src/tui/rings.rs
@@ -2,20 +2,10 @@ use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
 
 use super::model::{DashboardStats, RingStats};
+use super::theme;
 
 pub fn ring_color(ring: &str, warning_level: f64) -> Color {
-    if warning_level > 0.75 {
-        return Color::LightRed;
-    }
-    match ring {
-        "cambium" => Color::LightYellow,
-        "outer" => Color::LightMagenta,
-        "inner" => Color::Cyan,
-        "heartwood" => Color::Yellow,
-        "scar" => Color::Red,
-        "seed" => Color::LightCyan,
-        _ => Color::Gray,
-    }
+    theme::ring_color(ring, warning_level)
 }
 
 pub fn ring_style(stats: &RingStats) -> Style {
@@ -93,27 +83,43 @@ pub fn ambient_tree_lines(dashboard: &DashboardStats, tick: u64) -> Vec<Line<'st
 pub fn exploded_ring_lines(dashboard: &DashboardStats, selected_ring: usize) -> Vec<Line<'static>> {
     let mut lines = vec![Line::from(Span::styled(
         "EXPLODED RINGS".to_string(),
-        Style::default()
-            .fg(Color::White)
-            .add_modifier(Modifier::BOLD),
+        theme::title(),
     ))];
 
     for (index, stats) in dashboard.rings.iter().enumerate() {
         let marker = if index == selected_ring { ">" } else { " " };
         let bar = ring_bar(stats.total, dashboard.total);
         let top_types = stats.top_event_types(2).join(", ");
+        let marker_style = if index == selected_ring {
+            theme::secondary_accent().add_modifier(Modifier::BOLD)
+        } else {
+            theme::dim()
+        };
         lines.push(Line::from(vec![
-            Span::raw(format!("{marker} ")),
+            Span::styled(format!("{marker} "), marker_style),
             Span::styled(format!("{:<10}", stats.ring), ring_style(stats)),
-            Span::raw(format!(" {:>4} ", stats.total)),
+            Span::styled(
+                format!(" {:>4} ", stats.total),
+                if index == selected_ring {
+                    theme::selected()
+                } else {
+                    theme::title()
+                },
+            ),
             Span::styled(bar, ring_style(stats)),
-            Span::raw(format!(
-                " conf {:.2} sal {:.2} private {}",
-                stats.average_confidence, stats.average_salience, stats.sensitive_count
-            )),
+            Span::styled(
+                format!(
+                    " conf {:.2} sal {:.2} private {}",
+                    stats.average_confidence, stats.average_salience, stats.sensitive_count
+                ),
+                theme::dim(),
+            ),
         ]));
         if !top_types.is_empty() {
-            lines.push(Line::from(Span::raw(format!("    top: {top_types}"))));
+            lines.push(Line::from(vec![
+                Span::styled("    top: ", theme::dim()),
+                Span::styled(top_types, theme::accent()),
+            ]));
         }
     }
 

--- a/crates/tree-ring-memory-cli/src/tui/theme.rs
+++ b/crates/tree-ring-memory-cli/src/tui/theme.rs
@@ -1,0 +1,100 @@
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::widgets::{Block, Borders};
+
+pub const NAVY: Color = Color::Rgb(0, 31, 52);
+pub const TEAL: Color = Color::Rgb(22, 156, 166);
+pub const PINK: Color = Color::Rgb(239, 65, 103);
+pub const ORANGE: Color = Color::Rgb(255, 125, 34);
+pub const YELLOW: Color = Color::Rgb(255, 194, 69);
+pub const CREAM: Color = Color::Rgb(255, 245, 213);
+pub const CORAL: Color = Color::Rgb(255, 101, 83);
+pub const MUTED: Color = Color::Rgb(121, 135, 145);
+
+pub fn title() -> Style {
+    Style::default().fg(CREAM).add_modifier(Modifier::BOLD)
+}
+
+pub fn brand() -> Style {
+    Style::default().fg(YELLOW).add_modifier(Modifier::BOLD)
+}
+
+pub fn accent() -> Style {
+    Style::default().fg(TEAL)
+}
+
+pub fn secondary_accent() -> Style {
+    Style::default().fg(PINK)
+}
+
+pub fn warning() -> Style {
+    Style::default().fg(CORAL).add_modifier(Modifier::BOLD)
+}
+
+pub fn dim() -> Style {
+    Style::default().fg(MUTED)
+}
+
+pub fn selected() -> Style {
+    Style::default()
+        .fg(CREAM)
+        .bg(NAVY)
+        .add_modifier(Modifier::BOLD)
+}
+
+pub fn live() -> Style {
+    Style::default().fg(TEAL).add_modifier(Modifier::BOLD)
+}
+
+pub fn panel<'a>(title: impl Into<String>) -> Block<'a> {
+    Block::default()
+        .title(title.into())
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(TEAL))
+        .title_style(title_style())
+}
+
+pub fn plain_panel<'a>() -> Block<'a> {
+    Block::default()
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(TEAL))
+}
+
+fn title_style() -> Style {
+    Style::default().fg(YELLOW).add_modifier(Modifier::BOLD)
+}
+
+pub fn ring_color(ring: &str, warning_level: f64) -> Color {
+    if warning_level > 0.75 {
+        return CORAL;
+    }
+    match ring {
+        "cambium" => TEAL,
+        "outer" => PINK,
+        "inner" => ORANGE,
+        "heartwood" => YELLOW,
+        "scar" => CORAL,
+        "seed" => Color::Rgb(82, 210, 202),
+        _ => MUTED,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn maps_core_rings_to_brand_palette() {
+        assert_eq!(ring_color("cambium", 0.0), TEAL);
+        assert_eq!(ring_color("outer", 0.0), PINK);
+        assert_eq!(ring_color("inner", 0.0), ORANGE);
+        assert_eq!(ring_color("heartwood", 0.0), YELLOW);
+        assert_eq!(ring_color("scar", 0.0), CORAL);
+        assert_eq!(ring_color("seed", 0.0), Color::Rgb(82, 210, 202));
+        assert_eq!(ring_color("unknown", 0.0), MUTED);
+    }
+
+    #[test]
+    fn warning_overrides_ring_color() {
+        assert_eq!(ring_color("heartwood", 1.0), CORAL);
+    }
+}

--- a/crates/tree-ring-memory-cli/src/welcome.rs
+++ b/crates/tree-ring-memory-cli/src/welcome.rs
@@ -1,0 +1,167 @@
+use serde_json::json;
+use std::io::{self, IsTerminal, Write};
+use std::path::Path;
+use std::thread;
+use std::time::Duration;
+use tree_ring_memory_sqlite::SQLiteMemoryStore;
+
+const RESET: &str = "\x1b[0m";
+const TEAL: &str = "\x1b[38;5;37m";
+const PINK: &str = "\x1b[38;5;204m";
+const ORANGE: &str = "\x1b[38;5;208m";
+const YELLOW: &str = "\x1b[38;5;220m";
+const BLUE: &str = "\x1b[38;5;33m";
+const BOLD: &str = "\x1b[1m";
+
+pub fn run(root: &Path, init: bool, no_animation: bool, json_output: bool) -> Result<(), String> {
+    let db_path = root.join("memory.sqlite");
+    let initialized = if init {
+        SQLiteMemoryStore::open(&db_path).map_err(|err| err.to_string())?;
+        true
+    } else {
+        db_path.exists()
+    };
+
+    if json_output {
+        println!(
+            "{}",
+            json!({
+                "ok": true,
+                "root": root,
+                "sqlite_path": db_path,
+                "initialized": initialized,
+                "init_requested": init,
+                "next": next_commands(root),
+            })
+        );
+        return Ok(());
+    }
+
+    let color = io::stdout().is_terminal();
+    if color && !no_animation {
+        animate_intro()?;
+    }
+    print_static_welcome(root, initialized, init, color);
+    Ok(())
+}
+
+fn animate_intro() -> Result<(), String> {
+    let mut stdout = io::stdout();
+    for frame in 0..8 {
+        write!(stdout, "\x1b[2J\x1b[H").map_err(|err| err.to_string())?;
+        for line in ring_frame(frame, true) {
+            writeln!(stdout, "{line}").map_err(|err| err.to_string())?;
+        }
+        stdout.flush().map_err(|err| err.to_string())?;
+        thread::sleep(Duration::from_millis(90));
+    }
+    Ok(())
+}
+
+fn print_static_welcome(root: &Path, initialized: bool, init_requested: bool, color: bool) {
+    for line in ring_frame(7, color) {
+        println!("{line}");
+    }
+    println!();
+    println!("{}", paint("Tree Ring Memory is ready.", BOLD, color));
+    if initialized && init_requested {
+        println!(
+            "Project initialized at {}. Fresh memory can start in cambium.",
+            root.display()
+        );
+    } else if initialized {
+        println!(
+            "Memory root found at {}. You can recall or open the TUI now.",
+            root.display()
+        );
+    } else {
+        println!(
+            "No memory root yet at {}. Run init when you are ready.",
+            root.display()
+        );
+    }
+    println!("Local-first by default. Secret-like memory is blocked before storage.");
+    println!();
+    println!("{}", paint("Next useful commands", YELLOW, color));
+    for command in next_commands(root) {
+        println!("  {command}");
+    }
+}
+
+fn next_commands(root: &Path) -> Vec<String> {
+    vec![
+        format!("tree-ring --root {} init", shell_path(root)),
+        format!(
+            "tree-ring --root {} remember \"Use project-scoped recall before risky changes.\" --event-type lesson --scope project",
+            shell_path(root)
+        ),
+        format!("tree-ring --root {} tui", shell_path(root)),
+    ]
+}
+
+fn shell_path(path: &Path) -> String {
+    let value = path.display().to_string();
+    if value.contains(' ') {
+        format!("'{value}'")
+    } else {
+        value
+    }
+}
+
+fn ring_frame(frame: usize, color: bool) -> Vec<String> {
+    let pulse = if frame % 2 == 0 { "*" } else { "+" };
+    vec![
+        paint("        .-=================-.        ", TEAL, color) + pulse,
+        paint("     .-'   cambium  fresh   '-.     ", PINK, color),
+        paint("   .'   .--- outer  detailed ---.   '.", ORANGE, color),
+        paint("  /   .'   .-- inner  compressed --.  \\", YELLOW, color),
+        paint(" |   /   .' heartwood durable '.   | ", BLUE, color),
+        paint("  \\   '.   scars visible seeds   .'  /", PINK, color),
+        paint("   '.   '---.          .---'   .'   ", ORANGE, color),
+        paint("     '-.       '------'       .-'    ", TEAL, color),
+        paint("        '==================='        ", BLUE, color),
+    ]
+}
+
+fn paint(text: &str, color_code: &str, color: bool) -> String {
+    if color {
+        format!("{color_code}{text}{RESET}")
+    } else {
+        text.to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn next_commands_point_at_root_and_tui() {
+        let commands = next_commands(Path::new(".tree-ring"));
+
+        assert_eq!(commands.len(), 3);
+        assert!(commands[0].contains(" init"));
+        assert!(commands[2].contains(" tui"));
+    }
+
+    #[test]
+    fn no_animation_welcome_can_initialize_store() {
+        let dir = tempdir().unwrap();
+        let root = dir.path().join(".tree-ring");
+
+        run(&root, true, true, false).unwrap();
+
+        assert!(root.join("memory.sqlite").exists());
+    }
+
+    #[test]
+    fn json_welcome_can_initialize_store() {
+        let dir = tempdir().unwrap();
+        let root = dir.path().join(".tree-ring");
+
+        run(&root, true, true, true).unwrap();
+
+        assert!(root.join("memory.sqlite").exists());
+    }
+}

--- a/crates/tree-ring-memory-cli/src/welcome.rs
+++ b/crates/tree-ring-memory-cli/src/welcome.rs
@@ -18,8 +18,8 @@ const BOLD: &str = "\x1b[1m";
 pub fn run(root: &Path, init: bool, no_animation: bool, json_output: bool) -> Result<(), String> {
     let db_path = root.join("memory.sqlite");
     let (initialized, awareness) = if init {
-        SQLiteMemoryStore::open(&db_path).map_err(|err| err.to_string())?;
         let awareness = ensure_agent_awareness(root)?;
+        SQLiteMemoryStore::open(&db_path).map_err(|err| err.to_string())?;
         (true, Some(awareness))
     } else {
         (db_path.exists(), None)

--- a/crates/tree-ring-memory-cli/src/welcome.rs
+++ b/crates/tree-ring-memory-cli/src/welcome.rs
@@ -5,6 +5,8 @@ use std::thread;
 use std::time::Duration;
 use tree_ring_memory_sqlite::SQLiteMemoryStore;
 
+use crate::agent_awareness::{ensure_agent_awareness, AgentAwarenessReport};
+
 const RESET: &str = "\x1b[0m";
 const TEAL: &str = "\x1b[38;5;37m";
 const PINK: &str = "\x1b[38;5;204m";
@@ -15,11 +17,12 @@ const BOLD: &str = "\x1b[1m";
 
 pub fn run(root: &Path, init: bool, no_animation: bool, json_output: bool) -> Result<(), String> {
     let db_path = root.join("memory.sqlite");
-    let initialized = if init {
+    let (initialized, awareness) = if init {
         SQLiteMemoryStore::open(&db_path).map_err(|err| err.to_string())?;
-        true
+        let awareness = ensure_agent_awareness(root)?;
+        (true, Some(awareness))
     } else {
-        db_path.exists()
+        (db_path.exists(), None)
     };
 
     if json_output {
@@ -31,6 +34,7 @@ pub fn run(root: &Path, init: bool, no_animation: bool, json_output: bool) -> Re
                 "sqlite_path": db_path,
                 "initialized": initialized,
                 "init_requested": init,
+                "agent_awareness": awareness,
                 "next": next_commands(root),
             })
         );
@@ -41,7 +45,7 @@ pub fn run(root: &Path, init: bool, no_animation: bool, json_output: bool) -> Re
     if color && !no_animation {
         animate_intro()?;
     }
-    print_static_welcome(root, initialized, init, color);
+    print_static_welcome(root, initialized, init, awareness.as_ref(), color);
     Ok(())
 }
 
@@ -58,7 +62,13 @@ fn animate_intro() -> Result<(), String> {
     Ok(())
 }
 
-fn print_static_welcome(root: &Path, initialized: bool, init_requested: bool, color: bool) {
+fn print_static_welcome(
+    root: &Path,
+    initialized: bool,
+    init_requested: bool,
+    awareness: Option<&AgentAwarenessReport>,
+    color: bool,
+) {
     for line in ring_frame(7, color) {
         println!("{line}");
     }
@@ -81,6 +91,21 @@ fn print_static_welcome(root: &Path, initialized: bool, init_requested: bool, co
         );
     }
     println!("Local-first by default. Secret-like memory is blocked before storage.");
+    if let Some(awareness) = awareness {
+        println!();
+        println!("{}", paint("Agent awareness", YELLOW, color));
+        if awareness.created.is_empty() {
+            println!("  Existing guidance found in the memory root.");
+        } else {
+            for path in &awareness.created {
+                println!("  created {}", path.display());
+            }
+        }
+        println!("  Read SKILL.md for agent behavior and CLI.md for commands.");
+        println!(
+            "  Merge AGENTS.md guidance into the project root AGENTS.md for DOX-aware agents."
+        );
+    }
     println!();
     println!("{}", paint("Next useful commands", YELLOW, color));
     for command in next_commands(root) {
@@ -153,6 +178,9 @@ mod tests {
         run(&root, true, true, false).unwrap();
 
         assert!(root.join("memory.sqlite").exists());
+        assert!(root.join("AGENTS.md").exists());
+        assert!(root.join("SKILL.md").exists());
+        assert!(root.join("CLI.md").exists());
     }
 
     #[test]
@@ -163,5 +191,8 @@ mod tests {
         run(&root, true, true, true).unwrap();
 
         assert!(root.join("memory.sqlite").exists());
+        assert!(root.join("AGENTS.md").exists());
+        assert!(root.join("SKILL.md").exists());
+        assert!(root.join("CLI.md").exists());
     }
 }

--- a/docs/architecture/rust-core-status.md
+++ b/docs/architecture/rust-core-status.md
@@ -5,8 +5,8 @@ runtime. This page tracks the v0.2 Rust
 core, v0.3 native Python binding work, the Rust-native Ratatui terminal
 console, the v0.4 Rust-owned JSONL import/export path, and v0.5 deterministic
 audit checks, the v0.6 deterministic consolidation path, the v0.7 Rust-owned
-maintenance lifecycle, v0.8 Python-runtime removal, and v0.9 removal of tracked
-Python source from the canonical repo.
+maintenance lifecycle, v0.8 Python-runtime removal, v0.9 removal of tracked
+Python source from the canonical repo, and v0.10 installer/onboarding work.
 
 ## Current Status
 
@@ -44,12 +44,16 @@ Python source from the canonical repo.
   always-visible animated ASCII tree-ring view, SQLite store-watch refresh,
   optional JSONL event-stream pulses, search/detail panes, and confirmation
   gates for destructive or authority-changing actions.
+- The repository includes `install.sh` for one-line global or project-local
+  installs, plus `tree-ring welcome` for first-run terminal onboarding.
 
 ## Build Commands
 
 ```bash
 cargo test
+sh install.sh --help
 cargo run -p tree-ring-memory-cli -- --help
+cargo run -p tree-ring-memory-cli -- welcome --no-animation
 cargo run -p tree-ring-memory-cli -- tui --help
 cargo run -p tree-ring-memory-cli -- export --help
 cargo run -p tree-ring-memory-cli -- import --help

--- a/docs/integrations/agent-skill.md
+++ b/docs/integrations/agent-skill.md
@@ -5,6 +5,15 @@ Tree Ring Memory ships two integration aids for agent workflows:
 - `skills/tree-ring-memory/SKILL.md`: a portable agent skill that teaches an agent when to recall, remember, redact, forget, and avoid memory capture.
 - `templates/dox/AGENTS.md`: a DOX-style project contract template for repos that want Tree Ring Memory guidance alongside source code.
 
+`tree-ring init` and `tree-ring welcome --init` also create local copies in the
+configured memory root:
+
+- `.tree-ring/AGENTS.md`
+- `.tree-ring/SKILL.md`
+- `.tree-ring/CLI.md`
+
+Existing files are not overwritten.
+
 ## Skill Usage
 
 Use the skill in agent runtimes that support local skills or instruction packs.
@@ -29,15 +38,35 @@ Copy it to the project root as `AGENTS.md`, or merge its sections into an existi
 The contract intentionally says that Tree Ring Memory is not authoritative over source docs.
 Agents should still read local project instructions and source evidence directly.
 
+The CLI does not modify a project root `AGENTS.md` automatically. Merge the
+generated `.tree-ring/AGENTS.md` guidance manually when you want DOX-aware
+agents to encounter Tree Ring Memory instructions before entering `.tree-ring/`.
+
 ## Minimal CLI Flow
 
 ```bash
 tree-ring init
 tree-ring recall "project startup warnings"
 tree-ring remember "Use protocol-first design." --event-type decision --scope project --tag architecture
+tree-ring evidence "Snapshot invalidation fixed stale unread chat state." --outcome promoted --evidence-ref evals/chat-state/run-042 --score 0.91
 tree-ring forget mem_example --mode redact --reason "remove sensitive detail"
 tree-ring maintain
 ```
+
+## Evidence-Driven Improvement
+
+Use `tree-ring evidence` when a lesson comes from an evaluation, checkpoint,
+experiment, branch, incident, or reviewed run artifact.
+
+Outcome mapping:
+
+- `promoted` creates durable heartwood from supported evidence.
+- `rejected` creates a scar when a failed or rolled-back approach has reusable warning value.
+- `deferred` creates a seed for a promising but unresolved option.
+- `observed` creates an outer-ring evaluation result.
+
+Plain `remember` is still appropriate for user preferences, explicit decisions,
+and project lessons that do not come from a formal evaluated outcome.
 
 ## Safety Rule
 

--- a/docs/superpowers/plans/2026-07-05-tree-ring-memory-installer-onboarding-v0-10-implementation-plan.md
+++ b/docs/superpowers/plans/2026-07-05-tree-ring-memory-installer-onboarding-v0-10-implementation-plan.md
@@ -1,0 +1,73 @@
+# Tree Ring Memory Installer And Onboarding v0.10 Implementation Plan
+
+## Task 1: Add Rust Welcome Command
+
+Files:
+
+- `crates/tree-ring-memory-cli/src/main.rs`
+- `crates/tree-ring-memory-cli/src/welcome.rs`
+
+Work:
+
+- Add `tree-ring welcome`.
+- Add `--init` and `--no-animation` options.
+- Respect global `--root` and `--json`.
+- Print concise onboarding commands.
+- Initialize SQLite only when `--init` is present.
+- Add tests for no-animation output, init behavior, and JSON behavior.
+
+Checks:
+
+```bash
+cargo test -p tree-ring-memory-cli welcome
+cargo run -q -p tree-ring-memory-cli -- welcome --no-animation
+```
+
+## Task 2: Add Installer Script
+
+Files:
+
+- `install.sh`
+
+Work:
+
+- Implement POSIX shell installer.
+- Default to global install in `$HOME/.local`.
+- Add `--project`, `--init`, `--no-init`, `--no-animation`, `--install-dir`,
+  `--repo`, `--ref`, and `--source`.
+- Use `cargo install --path` for local source smoke and `cargo install --git`
+  for the curl path.
+- Run `tree-ring welcome` after successful install unless disabled.
+- Give clear recovery messages for missing cargo or failed install.
+
+Checks:
+
+```bash
+sh install.sh --help
+sh install.sh --source . --install-dir /tmp/tree-ring-install --no-animation --no-init
+```
+
+## Task 3: Update Docs And Verify
+
+Files:
+
+- `README.md`
+- `docs/architecture/rust-core-status.md`
+
+Work:
+
+- Add one-line install commands.
+- Add project-local install and init guidance.
+- Add TUI launch commands for installed and source-checkout paths.
+- Add installer checks to development commands.
+
+Final checks:
+
+```bash
+cargo test
+sh install.sh --help
+sh install.sh --source . --install-dir /tmp/tree-ring-install --no-animation --no-init
+cargo run -q -p tree-ring-memory-cli -- welcome --no-animation
+cargo run -q -p tree-ring-memory-cli -- --root /tmp/tree-ring-welcome welcome --init --no-animation
+git diff --check
+```

--- a/docs/superpowers/specs/2026-07-05-tree-ring-memory-installer-onboarding-v0-10-design.md
+++ b/docs/superpowers/specs/2026-07-05-tree-ring-memory-installer-onboarding-v0-10-design.md
@@ -1,0 +1,66 @@
+# Tree Ring Memory Installer And Onboarding v0.10 Design
+
+v0.10 adds a one-line installer and a terminal onboarding path that make Tree
+Ring Memory easy to try globally or inside a project.
+
+## Intent
+
+Tree Ring Memory should feel approachable without hiding that it is a serious
+local memory tool. The install flow should satisfy the basics first: it works,
+handles errors clearly, and leaves the user with obvious next commands. Delight
+comes from a short animated ASCII ring moment and useful guidance, not from a
+blocking wizard.
+
+## Goals
+
+- Provide a curl-friendly `install.sh`.
+- Support global install into `$HOME/.local/bin` by default.
+- Support project-local install into `.tree-ring/bin` with `--project`.
+- Support optional project initialization with `--init`.
+- Add a Rust-native `tree-ring welcome` command with terminal-safe ASCII rings.
+- Use animation only when stdout is a TTY and the user has not disabled it.
+- Keep non-interactive/scripted output deterministic with `--no-animation`.
+- Document how to install, initialize, and open the TUI.
+
+## Non-Goals
+
+- Do not require a package manager beyond an existing Rust toolchain.
+- Do not add shell dependencies beyond POSIX `sh` plus `cargo`.
+- Do not create cloud accounts or remote sync.
+- Do not initialize a project unless the user asks through `--init`.
+
+## Installer UX
+
+Default:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/TerminallyLazy/Tree-Ring-Memory/main/install.sh | sh
+```
+
+Project-local:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/TerminallyLazy/Tree-Ring-Memory/main/install.sh | sh -s -- --project --init
+```
+
+Emotional arc:
+
+- First encounter: clear retro tree-ring identity.
+- Setup: explain where the binary will go before building.
+- First success: confirm install and show the next three useful commands.
+- Recovery: explain missing Rust/cargo with a concrete fix.
+
+## Acceptance Criteria
+
+1. `install.sh --help` documents global, project, init, no-animation, local
+   source, and install-dir options.
+2. `install.sh --source . --install-dir <tmp> --no-animation --no-init` installs
+   a working `tree-ring` binary.
+3. `tree-ring welcome --no-animation` prints onboarding guidance without
+   opening SQLite.
+4. `tree-ring welcome --init --no-animation` initializes the configured root.
+5. `tree-ring welcome --json --init` emits a structured status payload.
+6. README includes one-line install, project-local install, and TUI launch
+   instructions.
+7. `cargo test` passes.
+8. `git diff --check` passes.

--- a/install.sh
+++ b/install.sh
@@ -154,7 +154,7 @@ intro() {
     for pulse in "*" "+" "*" "+"; do
       printf '\033[2J\033[H'
       ring_frame "$pulse"
-      sleep 0.08
+      sleep 0.08 2>/dev/null || :
     done
   else
     ring_frame "*"
@@ -180,6 +180,7 @@ install_prefix() {
   if [ "$INSTALL_SCOPE" = "project" ]; then
     printf '%s' ".tree-ring"
   else
+    [ "${HOME:-}" != "" ] || die "HOME is not set. Pass --install-dir or use --project."
     printf '%s' "$HOME/.local"
   fi
 }

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,243 @@
+#!/bin/sh
+set -eu
+
+REPO_URL=${TREE_RING_REPO:-"https://github.com/TerminallyLazy/Tree-Ring-Memory"}
+GIT_REF=${TREE_RING_REF:-"main"}
+INSTALL_SCOPE=${TREE_RING_INSTALL_SCOPE:-"global"}
+INSTALL_DIR=${TREE_RING_INSTALL_DIR:-""}
+SOURCE_DIR=${TREE_RING_SOURCE:-""}
+MEMORY_ROOT=${TREE_RING_ROOT:-".tree-ring"}
+RUN_INIT=${TREE_RING_INIT:-"0"}
+RUN_ONBOARDING=${TREE_RING_ONBOARDING:-"1"}
+ANIMATION=${TREE_RING_ANIMATION:-"1"}
+
+if [ ! -t 1 ] || [ "${NO_COLOR:-}" != "" ]; then
+  COLOR=0
+else
+  COLOR=1
+fi
+
+die() {
+  printf '%s\n' "Tree Ring Memory install failed: $*" >&2
+  exit 1
+}
+
+usage() {
+  cat <<'EOF'
+Tree Ring Memory installer
+
+Usage:
+  curl -fsSL https://raw.githubusercontent.com/TerminallyLazy/Tree-Ring-Memory/main/install.sh | sh
+  curl -fsSL https://raw.githubusercontent.com/TerminallyLazy/Tree-Ring-Memory/main/install.sh | sh -s -- --project --init
+
+Options:
+  --global              Install to $HOME/.local/bin (default).
+  --project             Install to .tree-ring/bin in the current project.
+  --init                Run tree-ring welcome --init after install.
+  --no-init             Do not initialize memory after install (default).
+  --no-animation        Print stable output without animated rings.
+  --no-onboarding       Skip tree-ring welcome after install.
+  --install-dir DIR     Override install prefix. Binary goes in DIR/bin.
+  --root DIR            Memory root used by onboarding/init (default .tree-ring).
+  --repo URL            Git repository used by cargo install.
+  --ref REF             Git branch used by cargo install (default main).
+  --source DIR          Install from a local checkout instead of git.
+  -h, --help            Show this help.
+
+Environment:
+  TREE_RING_INSTALL_SCOPE=global|project
+  TREE_RING_INSTALL_DIR=/path/to/prefix
+  TREE_RING_ROOT=.tree-ring
+  TREE_RING_REPO=https://github.com/TerminallyLazy/Tree-Ring-Memory
+  TREE_RING_REF=main
+  TREE_RING_SOURCE=/path/to/checkout
+  TREE_RING_INIT=1
+  TREE_RING_ANIMATION=0
+  TREE_RING_ONBOARDING=0
+EOF
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --global)
+      INSTALL_SCOPE=global
+      ;;
+    --project)
+      INSTALL_SCOPE=project
+      ;;
+    --init)
+      RUN_INIT=1
+      ;;
+    --no-init)
+      RUN_INIT=0
+      ;;
+    --no-animation)
+      ANIMATION=0
+      ;;
+    --no-onboarding)
+      RUN_ONBOARDING=0
+      ;;
+    --install-dir)
+      shift
+      [ "$#" -gt 0 ] || die "--install-dir requires a value"
+      INSTALL_DIR=$1
+      ;;
+    --root)
+      shift
+      [ "$#" -gt 0 ] || die "--root requires a value"
+      MEMORY_ROOT=$1
+      ;;
+    --repo)
+      shift
+      [ "$#" -gt 0 ] || die "--repo requires a value"
+      REPO_URL=$1
+      ;;
+    --ref)
+      shift
+      [ "$#" -gt 0 ] || die "--ref requires a value"
+      GIT_REF=$1
+      ;;
+    --source)
+      shift
+      [ "$#" -gt 0 ] || die "--source requires a value"
+      SOURCE_DIR=$1
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      die "unknown option: $1"
+      ;;
+  esac
+  shift
+done
+
+paint() {
+  code=$1
+  text=$2
+  if [ "$COLOR" = "1" ]; then
+    printf '\033[%sm%s\033[0m' "$code" "$text"
+  else
+    printf '%s' "$text"
+  fi
+}
+
+line() {
+  printf '%s\n' "$*"
+}
+
+ring_frame() {
+  pulse=$1
+  paint "38;5;37" "        .-=================-.        "
+  line "$pulse"
+  paint "38;5;204" "     .-'   cambium  fresh   '-.     "
+  line ""
+  paint "38;5;208" "   .'   .--- outer  detailed ---.   '."
+  line ""
+  paint "38;5;220" "  /   .'   .-- inner compressed --.  \\"
+  line ""
+  paint "38;5;33" " |   /   .' heartwood durable '.   | "
+  line ""
+  paint "38;5;204" "  \\   '.   scars visible seeds   .'  /"
+  line ""
+  paint "38;5;208" "   '.   '---.          .---'   .'   "
+  line ""
+  paint "38;5;37" "     '-.       '------'       .-'    "
+  line ""
+  paint "38;5;33" "        '==================='        "
+  line ""
+}
+
+intro() {
+  if [ "$ANIMATION" = "1" ] && [ "$COLOR" = "1" ]; then
+    for pulse in "*" "+" "*" "+"; do
+      printf '\033[2J\033[H'
+      ring_frame "$pulse"
+      sleep 0.08
+    done
+  else
+    ring_frame "*"
+  fi
+  line ""
+  paint "1" "Tree Ring Memory"
+  line " installer"
+  line "Framework-agnostic local memory for AI agents."
+  line ""
+}
+
+require_cargo() {
+  if ! command -v cargo >/dev/null 2>&1; then
+    die "cargo was not found. Install Rust from https://rustup.rs, then rerun this installer."
+  fi
+}
+
+install_prefix() {
+  if [ "$INSTALL_DIR" != "" ]; then
+    printf '%s' "$INSTALL_DIR"
+    return
+  fi
+  if [ "$INSTALL_SCOPE" = "project" ]; then
+    printf '%s' ".tree-ring"
+  else
+    printf '%s' "$HOME/.local"
+  fi
+}
+
+install_binary() {
+  prefix=$1
+  mkdir -p "$prefix"
+  line "Installing tree-ring into $prefix/bin"
+  line "Setting things up. This usually takes about 30 seconds after dependencies are cached."
+  if [ "$SOURCE_DIR" != "" ]; then
+    cargo install --path "$SOURCE_DIR/crates/tree-ring-memory-cli" --root "$prefix" --locked --force
+  else
+    cargo install --git "$REPO_URL" --branch "$GIT_REF" --package tree-ring-memory-cli --root "$prefix" --locked --force
+  fi
+}
+
+path_contains() {
+  case ":$PATH:" in
+    *":$1:"*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+intro
+require_cargo
+
+PREFIX=$(install_prefix)
+BIN="$PREFIX/bin/tree-ring"
+
+install_binary "$PREFIX"
+
+[ -x "$BIN" ] || die "expected installed binary at $BIN"
+"$BIN" --help >/dev/null || die "installed binary did not run"
+
+line ""
+paint "1" "Installed:"
+line " $BIN"
+
+if [ "$RUN_ONBOARDING" = "1" ]; then
+  WELCOME_FLAGS=""
+  if [ "$RUN_INIT" = "1" ]; then
+    WELCOME_FLAGS="$WELCOME_FLAGS --init"
+  fi
+  if [ "$ANIMATION" != "1" ]; then
+    WELCOME_FLAGS="$WELCOME_FLAGS --no-animation"
+  fi
+  # shellcheck disable=SC2086
+  "$BIN" --root "$MEMORY_ROOT" welcome $WELCOME_FLAGS
+fi
+
+line ""
+if [ "$INSTALL_SCOPE" = "global" ] && ! path_contains "$PREFIX/bin"; then
+  line "Add this to your shell profile if tree-ring is not found:"
+  line "  export PATH=\"$PREFIX/bin:\$PATH\""
+fi
+if [ "$INSTALL_SCOPE" = "project" ]; then
+  line "For project-local use:"
+  line "  export PATH=\"$PWD/$PREFIX/bin:\$PATH\""
+fi
+line "Open the TUI:"
+line "  $BIN --root $MEMORY_ROOT tui"

--- a/skills/tree-ring-memory/SKILL.md
+++ b/skills/tree-ring-memory/SKILL.md
@@ -55,6 +55,17 @@ Store a memory when the information is likely to help future work:
 
 Keep memory concise. Store the lesson, decision, or warning, not the full conversation.
 
+Use `tree-ring evidence` instead of plain `remember` when the lesson comes from
+an evaluation, checkpoint, experiment, branch, incident, or reviewed run
+artifact.
+
+Evidence outcome mapping:
+
+- `promoted`: durable heartwood from supported evidence
+- `rejected`: scar for reusable failed or rolled-back approaches
+- `deferred`: seed for promising unresolved options
+- `observed`: outer-ring evaluation result
+
 ## Ring Selection
 
 Use these rings:
@@ -108,6 +119,7 @@ Set project and scope deliberately:
 - use agent scope for agent-profile behavior
 - use global scope only for durable user preferences or cross-project guidance
 - include source references such as file paths, issue ids, PR ids, run ids, or docs paths
+- use `tree-ring evidence ... --evidence-ref <ref>` for evaluated outcomes
 
 Memory does not replace source documents. If a repo has `AGENTS.md`, project docs, tests, architectural records, or host-specific instruction files, read those sources directly and treat them as authoritative.
 

--- a/templates/dox/AGENTS.md
+++ b/templates/dox/AGENTS.md
@@ -43,6 +43,12 @@ Remember only meaningful information:
 
 Do not store full transcripts, scratchpad notes, raw chain-of-thought, secrets, credentials, or sensitive personal details.
 
+Use `tree-ring evidence` for evaluated outcomes from runs, checkpoints,
+experiments, incidents, PRs, issues, or reviewed artifacts. Promotions should
+become heartwood only when the evidence supports durable reuse. Rejections with
+reusable warning value should become scars. Deferred possibilities should become
+seeds.
+
 ## Ring Mapping
 
 - Use `cambium` for active task context.


### PR DESCRIPTION
Summary:
- Bring the Rust-only v0.10 stack to main: one-line installer, terminal onboarding, and README install/TUI instructions.
- Add Tree Ring Memory retro palette accents to the Ratatui TUI.
- Add non-destructive agent-awareness scaffolding under `.tree-ring/`: AGENTS.md, SKILL.md, and CLI.md.
- Add `tree-ring evidence` for the Revolve-inspired evidence loop with promoted/rejected/deferred/observed outcome mapping.

Verification:
- cargo test: passed.
- Real init smoke created memory.sqlite, AGENTS.md, SKILL.md, and CLI.md.
- Real evidence smoke stored promoted evidence as heartwood and recalled it by project.
- Installer smoke passed earlier with --source, --project, --init, --no-animation.

Notes:
- This follows merged PRs #14 and #15, which were stacked on codex/rust-only-repo-v0.9.
- .vscode/ remains untracked and was not included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new welcome/onboarding experience for first-time use, including optional initialization and a no-animation mode.
  * Introduced an evidence-based workflow for recording evaluated outcomes, with clearer result reporting.
  * Added a one-line installer with support for global or project-local setup.

* **Bug Fixes**
  * Prevented onboarding files from being overwritten if they already exist.

* **Documentation**
  * Expanded the README and related guides with updated install, onboarding, and workflow examples.
  * Updated version references to **v0.10.0** across project metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->