### PR TITLE
Update CLI and adapter guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,8 +74,8 @@ files in the memory root:
 - `.tree-ring/AGENTS.md`: DOX-style Tree Ring Memory guidance and root
   `AGENTS.md` merge notes.
 - `.tree-ring/SKILL.md`: portable skill instructions for agent runtimes.
-- `.tree-ring/CLI.md`: quick command reference for recall, remember, forget,
-  maintain, and TUI usage.
+- `.tree-ring/CLI.md`: quick command reference for recall, remember, evidence,
+  DOX/Revolve sync, import/export, audit, maintenance, and TUI usage.
 
 Existing awareness files are left untouched. Tree Ring Memory does not modify a
 project's root `AGENTS.md`; merge the generated guidance manually when you want
@@ -163,6 +163,16 @@ tree-ring integrations scan --source-root .
 
 The CLI stores memory in `.tree-ring/` by default.
 
+Command ownership is Rust-native:
+
+- `init` creates the SQLite store plus `.tree-ring/AGENTS.md`, `.tree-ring/SKILL.md`, and `.tree-ring/CLI.md` without overwriting existing files.
+- `remember`, `recall`, and `forget` cover direct memory capture, retrieval, redaction, and deletion.
+- `evidence` is the Revolve-inspired improvement-loop entry point for evaluated outcomes.
+- `dox sync` and `revolve sync` are read-only source adapters that summarize and point back to authoritative files.
+- `integrations scan` discovers nearby agent-framework markers and suggests setup paths without changing their config.
+- `export`, `import`, `audit`, `consolidate`, and `maintain` are local maintenance surfaces over the same SQLite store.
+- `welcome` and `tui` are the terminal onboarding and operator-console surfaces.
+
 ## Evidence Loop
 
 The Revolve-inspired loop is exposed through `tree-ring evidence`. It records
@@ -207,9 +217,20 @@ tree-ring revolve sync --source-root revolve --project example-service
 ```
 
 DOX sync discovers `AGENTS.md` files, stores summaries and source refs, and
-keeps the source files authoritative. Revolve sync imports promoted outcomes as
-heartwood, rejected outcomes as scars, deferred hypotheses as seeds, and
-observed results as outer-ring evidence.
+keeps the source files authoritative. It can scan a project root or a single
+`AGENTS.md` file. It does not copy entire project-contract trees into memory,
+does not weaken child contracts, and does not let memory replace fresh DOX
+traversal before edits.
+
+Revolve sync scans a Revolve root or an evidence file. It imports promoted
+outcomes as heartwood, rejected outcomes as scars, deferred hypotheses as
+seeds, and observed results as outer-ring evidence. It keeps source refs back
+to the Revolve/evaluation record and does not treat incomparable or
+outcome-free files as durable truth.
+
+For both adapters, run `--dry-run` first. Imported memory is a concise recall
+aid; the source `AGENTS.md`, Revolve record, evaluation artifact, PR, issue,
+test, or run log remains authoritative.
 
 Framework discovery is read-only:
 
@@ -297,7 +318,7 @@ Event stream lines are local JSONL objects. They are display signals only:
 ## Development Checks
 
 ```bash
-cargo test
+cargo test --locked
 sh install.sh --help
 cargo run -p tree-ring-memory-cli -- --help
 cargo run -p tree-ring-memory-cli -- welcome --no-animation
@@ -344,6 +365,13 @@ binding options that have since been superseded by the Rust-native runtime.
 For DOX-style project awareness, merge the relevant generated `.tree-ring/AGENTS.md`
 sections into the project root `AGENTS.md`. The CLI intentionally does not
 rewrite root project contracts automatically.
+
+For agent harnesses that support local skills or instruction packs, point them
+at `.tree-ring/SKILL.md` or the repository copy under `skills/`. For
+DOX-aware agents, make sure the project root `AGENTS.md` tells the agent to read
+Tree Ring Memory guidance when memory is initialized. For CLI-driven agents,
+include `.tree-ring/CLI.md` in the harness prompt or startup context so the
+agent knows the exact local commands.
 
 ## Brand Assets
 

--- a/crates/tree-ring-memory-cli/src/agent_awareness.rs
+++ b/crates/tree-ring-memory-cli/src/agent_awareness.rs
@@ -25,6 +25,9 @@ tree-ring remember "Use project-scoped recall before risky changes." --event-typ
 tree-ring evidence "Snapshot invalidation fixed stale unread chat state." --outcome promoted --evidence-ref evals/chat-state/run-042 --score 0.91
 tree-ring evidence "Aggressive caching caused stale multi-chat state." --outcome rejected --evidence-ref evals/cache-branch/run-013
 tree-ring forget mem_example --mode redact --reason "remove sensitive detail"
+tree-ring export --output memories.jsonl
+tree-ring import memories.jsonl --dry-run
+tree-ring audit --audit-type all
 tree-ring consolidate --period-type manual --dry-run
 tree-ring maintain
 tree-ring dox sync --source-root . --dry-run
@@ -32,6 +35,13 @@ tree-ring revolve sync --source-root revolve --dry-run
 tree-ring integrations scan --source-root .
 tree-ring tui
 ```
+
+Adapter rules:
+
+- `tree-ring dox sync` summarizes `AGENTS.md` files and keeps source contracts authoritative.
+- `tree-ring revolve sync` imports promoted, rejected, deferred, or observed evidence records without replacing Revolve/evaluation docs.
+- `tree-ring evidence` records individual evaluated outcomes with an explicit source ref.
+- Run adapter commands with `--dry-run` before writing memory.
 
 Safety rules:
 
@@ -109,7 +119,11 @@ Read `CLI.md` for local commands. Common commands:
 ```bash
 tree-ring --root {root} recall "project startup warnings"
 tree-ring --root {root} remember "Use project-scoped recall before risky changes." --event-type lesson --scope project
+tree-ring --root {root} evidence "A promoted evaluation fixed stale state." --outcome promoted --evidence-ref evals/run-042 --score 0.91
 tree-ring --root {root} forget mem_example --mode redact --reason "remove sensitive detail"
+tree-ring --root {root} dox sync --source-root . --dry-run
+tree-ring --root {root} revolve sync --source-root revolve --dry-run
+tree-ring --root {root} integrations scan --source-root .
 tree-ring --root {root} tui
 ```
 
@@ -118,6 +132,23 @@ tree-ring --root {root} tui
 If this project uses DOX-style `AGENTS.md` traversal, merge the relevant
 sections from the template below into the project root `AGENTS.md`. Tree Ring
 Memory does not overwrite root project contracts automatically.
+
+Use `tree-ring --root {root} dox sync --source-root . --dry-run` to preview
+concise memory summaries for local `AGENTS.md` files. The source contracts
+remain authoritative; memory is only a recall aid.
+
+## Revolve And Evidence Integration
+
+Use `tree-ring --root {root} evidence ... --evidence-ref <ref>` for individual
+evaluated outcomes. Use the Revolve sync command below to preview source-linked
+memories from Revolve/evaluation records:
+
+```bash
+tree-ring --root {root} revolve sync --source-root revolve --dry-run
+```
+
+Promoted outcomes become heartwood, rejected outcomes become scars, deferred
+outcomes become seeds, and observed outcomes become outer-ring evidence.
 
 ---
 
@@ -169,6 +200,10 @@ mod tests {
         assert!(agents.contains("SKILL.md"));
         assert!(agents.contains("CLI.md"));
         assert!(agents.contains("DOX Integration"));
+        assert!(agents.contains("Revolve And Evidence Integration"));
+        assert!(agents.contains("dox sync --source-root"));
+        assert!(agents.contains("revolve sync --source-root"));
+        assert!(agents.contains("integrations scan --source-root"));
         assert!(agents.contains("Tree Ring Memory Project Contract"));
     }
 

--- a/docs/architecture/rust-core-roadmap.md
+++ b/docs/architecture/rust-core-roadmap.md
@@ -50,6 +50,10 @@ The Rust core must support:
 - recall ranking with explainable scores
 - delete, redact, and supersede workflows
 - JSON import/export compatibility with the published schemas
+- deterministic audit, consolidation, and maintenance planning
+- DOX-style `AGENTS.md` summarization without replacing source contracts
+- Revolve/evaluation evidence import without replacing source records
+- a scriptable CLI plus a terminal operator console for local workflows
 
 v0.4 implements the JSONL import/export baseline in Rust and exposes it through
 the CLI. Markdown exports, SQLite backups, and signed bundles remain future
@@ -77,7 +81,9 @@ v0.10 adds one-line installer onboarding and the Rust-native terminal welcome
 flow.
 
 v0.11 adds Rust-native DOX and Revolve source adapters, TUI export and
-consolidation backend actions, and read-only agent-framework discovery.
+consolidation backend actions, read-only agent-framework discovery, and
+terminal onboarding/operator docs that point agents at the CLI, skill, and
+DOX-style project contract.
 
 ## Non-Goals
 

--- a/docs/architecture/rust-core-status.md
+++ b/docs/architecture/rust-core-status.md
@@ -14,7 +14,9 @@ v0.11 Rust-native source adapters plus framework discovery.
 - Rust workspace exists under `crates/`.
 - Rust core owns model validation, sensitivity checks, and recall scoring.
 - Rust SQLite crate owns schema-compatible SQLite/FTS storage.
-- Rust CLI can initialize, remember, recall, and forget local memory.
+- Rust CLI owns the full local command surface: init, remember, evidence,
+  recall, forget, import/export, audit, consolidate, maintain, DOX sync,
+  Revolve sync, framework discovery, welcome onboarding, and TUI operation.
 - Rust CLI has JSON output for machine-readable adapter use.
 - The repository no longer tracks a root Python package, Python wrapper layer,
   pytest suite, Python smoke scripts, PyO3 crate, or CPython extension.

--- a/docs/integrations/agent-skill.md
+++ b/docs/integrations/agent-skill.md
@@ -49,8 +49,19 @@ tree-ring init
 tree-ring recall "project startup warnings"
 tree-ring remember "Use protocol-first design." --event-type decision --scope project --tag architecture
 tree-ring evidence "Snapshot invalidation fixed stale unread chat state." --outcome promoted --evidence-ref evals/chat-state/run-042 --score 0.91
+tree-ring dox sync --source-root . --dry-run
+tree-ring revolve sync --source-root revolve --dry-run
+tree-ring integrations scan --source-root .
 tree-ring forget mem_example --mode redact --reason "remove sensitive detail"
 tree-ring maintain
+```
+
+For a project-local install, use the generated quick reference in
+`.tree-ring/CLI.md` and pass the project memory root explicitly when needed:
+
+```bash
+.tree-ring/bin/tree-ring --root .tree-ring recall "project startup warnings"
+.tree-ring/bin/tree-ring --root .tree-ring tui
 ```
 
 ## Evidence-Driven Improvement
@@ -67,6 +78,49 @@ Outcome mapping:
 
 Plain `remember` is still appropriate for user preferences, explicit decisions,
 and project lessons that do not come from a formal evaluated outcome.
+
+## Source Adapter Flow
+
+Use DOX and Revolve adapters when the source artifacts already exist locally:
+
+```bash
+tree-ring dox sync --source-root . --dry-run
+tree-ring revolve sync --source-root revolve --dry-run
+```
+
+The adapters are Rust-native and local-only. They create concise, source-linked
+memory events through the same SQLite store as manual memories. They do not
+modify root `AGENTS.md` files, rewrite DOX contracts, mutate Revolve records,
+or import raw run-log bloat.
+
+DOX adapter rules:
+
+- Scan a project root or a single `AGENTS.md` file.
+- Store concise summaries and source refs.
+- Treat source `AGENTS.md` files as authoritative.
+- Re-read the DOX chain before editing files.
+
+Revolve adapter rules:
+
+- Scan a Revolve root or an evidence file.
+- Import promoted outcomes as heartwood.
+- Import reusable rejected outcomes as scars.
+- Import deferred hypotheses as seeds.
+- Import observed results as outer-ring evidence.
+- Ignore outcome-free files as durable truth.
+
+Run `--dry-run` first, inspect the generated memories, then rerun without
+`--dry-run` only when the summaries are useful and source-linked.
+
+## Agent Harness Notes
+
+Tree Ring Memory is framework-agnostic. For agent harnesses that support local
+skills, add `skills/tree-ring-memory/SKILL.md` or the generated
+`.tree-ring/SKILL.md` to startup context. For DOX-aware harnesses, merge the
+generated `.tree-ring/AGENTS.md` guidance into the project root `AGENTS.md`
+when you want agents to see memory rules before entering the memory directory.
+For CLI-only harnesses, include `.tree-ring/CLI.md` in startup context and call
+`tree-ring --help` when command flags are uncertain.
 
 ## Safety Rule
 

--- a/skills/tree-ring-memory/SKILL.md
+++ b/skills/tree-ring-memory/SKILL.md
@@ -2,7 +2,7 @@
 name: tree-ring-memory
 description: Guides AI agents in using Tree Ring Memory for durable recall, project decisions, user preferences, warnings, future seeds, privacy-safe memory capture, and lifecycle-aware forgetting.
 version: 0.11.0
-tags: ["memory", "agents", "recall", "privacy", "projects", "dox", "skills"]
+tags: ["memory", "agents", "recall", "privacy", "projects", "dox", "revolve", "skills", "cli"]
 triggers:
   - "remember this"
   - "recall what we decided"
@@ -11,6 +11,9 @@ triggers:
   - "consolidate memory"
   - "forget this"
   - "project memory"
+  - "sync DOX"
+  - "sync Revolve"
+  - "evidence loop"
 ---
 
 # Tree Ring Memory
@@ -71,6 +74,18 @@ tree-ring integrations scan --source-root .
 Run adapter commands with `--dry-run` first. Sync only concise, source-linked
 summaries; never treat imported memory as more authoritative than the source
 `AGENTS.md`, Revolve record, evaluation, PR, issue, or test artifact.
+
+Use the exact CLI commands exposed by the local install:
+
+```bash
+tree-ring --help
+tree-ring dox sync --help
+tree-ring revolve sync --help
+tree-ring evidence --help
+```
+
+If the project was initialized with a project-local binary, prefer the generated
+`.tree-ring/CLI.md` reference and include `--root .tree-ring` when needed.
 
 Evidence outcome mapping:
 
@@ -138,6 +153,10 @@ Set project and scope deliberately:
 - use `tree-ring integrations scan` before configuring a new agent harness
 
 Memory does not replace source documents. If a repo has `AGENTS.md`, project docs, tests, architectural records, or host-specific instruction files, read those sources directly and treat them as authoritative.
+
+When DOX or Revolve source records change, re-run the matching sync adapter with
+`--dry-run`, inspect the generated memories, then run the write command only
+when the summaries are useful and source-linked.
 
 ## Forgetting And Correction
 

--- a/templates/dox/AGENTS.md
+++ b/templates/dox/AGENTS.md
@@ -49,6 +49,18 @@ become heartwood only when the evidence supports durable reuse. Rejections with
 reusable warning value should become scars. Deferred possibilities should become
 seeds.
 
+Use source adapters when local authoritative files already contain the guidance
+or evaluated outcome:
+
+```bash
+tree-ring dox sync --source-root . --dry-run
+tree-ring revolve sync --source-root revolve --dry-run
+tree-ring integrations scan --source-root .
+```
+
+Run adapter syncs as previews first. Persist only concise, source-linked
+summaries that help future recall.
+
 ## Ring Mapping
 
 - Use `cambium` for active task context.
@@ -78,3 +90,8 @@ Memory summaries should point back to source evidence such as:
 - local project docs
 
 When source documents and memory disagree, re-read the source documents and update or forget the stale memory.
+
+DOX-style `AGENTS.md` files and Revolve/evaluation records remain
+authoritative. Tree Ring Memory can summarize and point to them, but it must not
+replace DOX traversal, copy whole contract trees, treat stale scores as current
+truth, or promote an outcome without source evidence.


### PR DESCRIPTION
Summary:
- Expand README CLI ownership, DOX sync, Revolve sync, evidence-loop, and agent-harness guidance.
- Update generated .tree-ring/CLI.md and AGENTS.md content so initialized projects point agents at evidence, DOX/Revolve sync, integrations scan, and TUI commands.
- Align the portable skill, DOX template, integration doc, and Rust architecture docs with the current Rust-native CLI/adapters.
- Add tests that keep generated agent-awareness files from losing DOX/Revolve/CLI adapter references.

Verification:
- cargo fmt --all
- cargo test -p tree-ring-memory-cli agent_awareness --locked
- cargo test --locked
- cargo build -p tree-ring-memory-cli --locked
- sh -n install.sh
- git diff --check
- live init smoke verified generated AGENTS.md, SKILL.md, and CLI.md include dox sync, revolve sync, evidence, and integrations scan guidance.

Notes:
- PR #19 had already merged, so this is a follow-up PR for the documentation and generated-awareness updates.
- Local .DS_Store, .agents/, .vscode/, and skills-lock.json remain untracked.