### PR TITLE
Update bridge and installer documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,13 +45,23 @@ suite, Python smoke script, PyO3 crate, or CPython extension.
 Global user install:
 
 ```bash
-installer=$(mktemp) && curl -fsSL https://raw.githubusercontent.com/TerminallyLazy/Tree-Ring-Memory/main/install.sh -o "$installer" && sh "$installer"
+(
+  installer=$(mktemp) &&
+  trap 'rm -f "$installer"' EXIT &&
+  curl -fsSL https://raw.githubusercontent.com/TerminallyLazy/Tree-Ring-Memory/main/install.sh -o "$installer" &&
+  sh "$installer"
+)
 ```
 
 Project-local install with first-run initialization:
 
 ```bash
-installer=$(mktemp) && curl -fsSL https://raw.githubusercontent.com/TerminallyLazy/Tree-Ring-Memory/main/install.sh -o "$installer" && sh "$installer" --project --init
+(
+  installer=$(mktemp) &&
+  trap 'rm -f "$installer"' EXIT &&
+  curl -fsSL https://raw.githubusercontent.com/TerminallyLazy/Tree-Ring-Memory/main/install.sh -o "$installer" &&
+  sh "$installer" --project --init
+)
 ```
 
 The installer builds the Rust CLI with `cargo`, installs `tree-ring`, then shows
@@ -60,13 +70,15 @@ useful commands. For global installs, it also adds the install bin directory to 
 shell profile when that directory is not already on `PATH`. It does not
 initialize memory unless `--init` is passed.
 
-The installer command intentionally downloads only the installer script to a
-temporary file before running it. It does not put memory in a temporary
-location. Persistent memory lives in the configured memory root, normally
-`.tree-ring` for project-local use or whatever path you pass with `--root`.
-Avoid `curl ... | sh` here: if the download fails before producing script
-content, the shell can still exit successfully after running empty input, which
-looks like a silent no-op.
+The installer command intentionally downloads only the installer script to a new
+temporary file before running it. The subshell cleanup trap removes that
+temporary script when the command finishes. It does not put memory in a
+temporary location and it does not remove `.tree-ring`, installed binaries,
+Cargo caches, source checkouts, or shell profiles. Persistent memory lives in
+the configured memory root, normally `.tree-ring` for project-local use or
+whatever path you pass with `--root`. Avoid `curl ... | sh` here: if the
+download fails before producing script content, the shell can still exit
+successfully after running empty input, which looks like a silent no-op.
 
 Initialization creates the SQLite store and non-destructive agent-awareness
 files in the memory root:
@@ -242,6 +254,16 @@ It looks for local markers for DOX, Revolve, Codex, Claude Code, Agent Zero/A0,
 Goose, OpenCode, Hermes, and Pi, then suggests next steps without editing those
 tools' configuration.
 
+Agent-mediated bridge linking is the planned next step after read-only
+discovery. The design keeps `.tree-ring` as the canonical memory root while
+adding small project-level bridge files that tell the active agent to read
+`.tree-ring/SKILL.md` and `.tree-ring/CLI.md`. Project bridges are preferred
+because they travel with the repo; global bridges affect every project and must
+remain explicit opt-in. Until `tree-ring integrations link` is implemented, add
+those references manually in the harness startup context or project instruction
+file instead of expecting `tree-ring init` to modify Codex, Claude, Pi,
+OpenCode, or other agent configuration.
+
 `tree-ring export` writes newline-delimited JSON. The first line is a
 `tree_ring_memory_export` header with schema and plugin version metadata; each
 remaining line is a `memory_event` envelope. The command excludes sensitive and
@@ -354,6 +376,8 @@ run the release artifact workflow for Linux and macOS.
 Historical migration and planning documents are retained under `docs/superpowers/`
 and `docs/feature/`. Some of those records describe earlier Python prototype or
 binding options that have since been superseded by the Rust-native runtime.
+The current bridge-linking design is tracked in
+`docs/superpowers/specs/2026-07-06-tree-ring-agent-mediated-bridges-design.md`.
 
 ## Agent Workflow Integration
 
@@ -372,6 +396,20 @@ DOX-aware agents, make sure the project root `AGENTS.md` tells the agent to read
 Tree Ring Memory guidance when memory is initialized. For CLI-driven agents,
 include `.tree-ring/CLI.md` in the harness prompt or startup context so the
 agent knows the exact local commands.
+
+Bridge files should be short discovery pointers, not duplicate memory stores.
+Recommended project-level bridge targets are `.agents/skills/tree-ring-memory/SKILL.md`
+for Codex/Gemini-style skill loaders, `.claude/skills/tree-ring-memory/SKILL.md`
+plus `CLAUDE.md` references for Claude Code, root `AGENTS.md` references for
+OpenCode/DOX-style agents, and `.pi/settings.json` resource references for Pi.
+Global bridge files under home directories are useful only when the user wants
+Tree Ring visible in every project.
+
+Memory updates are agent-mediated. Bridge files tell the active agent when to
+call `tree-ring recall`, `tree-ring remember`, `tree-ring evidence`,
+`tree-ring forget`, `tree-ring consolidate --dry-run`, or `tree-ring maintain`.
+Tree Ring does not scrape transcripts, run a hidden recorder, or turn TUI
+event-stream pulses into durable memory without an explicit write command.
 
 ## Brand Assets
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Global user install:
 ```bash
 (
   installer=$(mktemp) &&
-  trap 'rm -f "$installer"' EXIT &&
+  trap 'rm -f "$installer"' EXIT INT TERM &&
   curl -fsSL https://raw.githubusercontent.com/TerminallyLazy/Tree-Ring-Memory/main/install.sh -o "$installer" &&
   sh "$installer"
 )
@@ -58,7 +58,7 @@ Project-local install with first-run initialization:
 ```bash
 (
   installer=$(mktemp) &&
-  trap 'rm -f "$installer"' EXIT &&
+  trap 'rm -f "$installer"' EXIT INT TERM &&
   curl -fsSL https://raw.githubusercontent.com/TerminallyLazy/Tree-Ring-Memory/main/install.sh -o "$installer" &&
   sh "$installer" --project --init
 )
@@ -72,13 +72,14 @@ initialize memory unless `--init` is passed.
 
 The installer command intentionally downloads only the installer script to a new
 temporary file before running it. The subshell cleanup trap removes that
-temporary script when the command finishes. It does not put memory in a
-temporary location and it does not remove `.tree-ring`, installed binaries,
-Cargo caches, source checkouts, or shell profiles. Persistent memory lives in
-the configured memory root, normally `.tree-ring` for project-local use or
-whatever path you pass with `--root`. Avoid `curl ... | sh` here: if the
-download fails before producing script content, the shell can still exit
-successfully after running empty input, which looks like a silent no-op.
+temporary script when the command finishes or receives `INT`/`TERM`. It does
+not put memory in a temporary location and it does not remove `.tree-ring`,
+installed binaries, Cargo caches, source checkouts, or shell profiles.
+Persistent memory lives in the configured memory root, normally `.tree-ring`
+for project-local use or whatever path you pass with `--root`. Avoid
+`curl ... | sh` here: if the download fails before producing script content,
+the shell can still exit successfully after running empty input, which looks
+like a silent no-op.
 
 Initialization creates the SQLite store and non-destructive agent-awareness
 files in the memory root:

--- a/crates/tree-ring-memory-cli/src/agent_awareness.rs
+++ b/crates/tree-ring-memory-cli/src/agent_awareness.rs
@@ -36,17 +36,26 @@ tree-ring integrations scan --source-root .
 tree-ring tui
 ```
 
+Project bridge files:
+
+- keep `.tree-ring/SKILL.md` and `.tree-ring/CLI.md` canonical
+- point harness-native files at those generated references
+- prefer project-level bridges over global bridges
+- treat global bridges as explicit opt-in user configuration
+
 Adapter rules:
 
 - `tree-ring dox sync` summarizes `AGENTS.md` files and keeps source contracts authoritative.
 - `tree-ring revolve sync` imports promoted, rejected, deferred, or observed evidence records without replacing Revolve/evaluation docs.
 - `tree-ring evidence` records individual evaluated outcomes with an explicit source ref.
 - Run adapter commands with `--dry-run` before writing memory.
+- `tree-ring integrations scan` is read-only; add harness bridge references manually until a link command is available.
 
 Safety rules:
 
 - Do not store secrets, credentials, private keys, or raw chain-of-thought.
 - Prefer concise, source-linked summaries over transcript capture.
+- Do not scrape chats or turn TUI event-stream pulses into durable memory without an explicit write command.
 - Treat local source files, tests, explicit user instructions, and root `AGENTS.md` files as authoritative.
 - When memory and source docs disagree, re-read source docs and update or forget stale memory.
 "#;
@@ -126,6 +135,23 @@ tree-ring --root {root} revolve sync --source-root revolve --dry-run
 tree-ring --root {root} integrations scan --source-root .
 tree-ring --root {root} tui
 ```
+
+## Harness Bridges
+
+Harness-native bridge files should point back to this directory instead of
+copying memory data. Recommended project bridges include `.agents/skills` for
+Codex/Gemini-style skill loaders, `.claude/skills` plus `CLAUDE.md` references
+for Claude Code, root `AGENTS.md` references for OpenCode/DOX-style agents, and
+`.pi/settings.json` resource references for Pi.
+
+Project-level bridges are preferred because they stay scoped to the current
+repo. Global bridges affect every project and should be treated as explicit
+user opt-in configuration.
+
+Tree Ring Memory is agent-mediated. Bridge files tell the active agent when to
+call `tree-ring recall`, `tree-ring remember`, `tree-ring evidence`,
+`tree-ring forget`, `tree-ring consolidate --dry-run`, or `tree-ring maintain`.
+They do not authorize hidden transcript scraping or autonomous durable writes.
 
 ## DOX Integration
 

--- a/crates/tree-ring-memory-cli/src/agent_awareness.rs
+++ b/crates/tree-ring-memory-cli/src/agent_awareness.rs
@@ -139,9 +139,10 @@ tree-ring --root {root} tui
 ## Harness Bridges
 
 Harness-native bridge files should point back to this directory instead of
-copying memory data. Recommended project bridges include `.agents/skills` for
-Codex/Gemini-style skill loaders, `.claude/skills` plus `CLAUDE.md` references
-for Claude Code, root `AGENTS.md` references for OpenCode/DOX-style agents, and
+copying memory data. Recommended project bridges include
+`.agents/skills/tree-ring-memory/SKILL.md` for Codex/Gemini-style skill loaders,
+`.claude/skills/tree-ring-memory/SKILL.md` plus `CLAUDE.md` references for
+Claude Code, root `AGENTS.md` references for OpenCode/DOX-style agents, and
 `.pi/settings.json` resource references for Pi.
 
 Project-level bridges are preferred because they stay scoped to the current

--- a/docs/architecture/rust-core-status.md
+++ b/docs/architecture/rust-core-status.md
@@ -53,6 +53,11 @@ v0.11 Rust-native source adapters plus framework discovery.
   replacing DOX contracts or Revolve evidence records.
 - The Rust CLI and TUI include read-only agent-framework discovery for DOX,
   Revolve, Codex, Claude Code, Agent Zero/A0, Goose, OpenCode, Hermes, and Pi.
+- Project-local agent guidance is generated under `.tree-ring/AGENTS.md`,
+  `.tree-ring/SKILL.md`, and `.tree-ring/CLI.md`. The current bridge-linking
+  design keeps those files canonical, prefers project-level harness bridges,
+  leaves global harness configuration opt-in, and keeps durable memory updates
+  agent-mediated instead of background-recorded.
 
 ## Build Commands
 

--- a/docs/integrations/agent-skill.md
+++ b/docs/integrations/agent-skill.md
@@ -14,6 +14,10 @@ configured memory root:
 
 Existing files are not overwritten.
 
+These generated files are the canonical project-local guidance. Harness-native
+bridge files should point back to them rather than copying memory data or
+duplicating long instructions.
+
 ## Skill Usage
 
 Use the skill in agent runtimes that support local skills or instruction packs.
@@ -121,6 +125,34 @@ generated `.tree-ring/AGENTS.md` guidance into the project root `AGENTS.md`
 when you want agents to see memory rules before entering the memory directory.
 For CLI-only harnesses, include `.tree-ring/CLI.md` in startup context and call
 `tree-ring --help` when command flags are uncertain.
+
+Recommended project-level bridge targets:
+
+- Codex and Gemini-style skill loaders: `.agents/skills/tree-ring-memory/SKILL.md`
+  pointing to `.tree-ring/SKILL.md` and `.tree-ring/CLI.md`.
+- Claude Code: `.claude/skills/tree-ring-memory/SKILL.md` plus a `CLAUDE.md`
+  reference to `.tree-ring/AGENTS.md` and `.tree-ring/CLI.md`.
+- OpenCode and DOX-style agents: a root `AGENTS.md` managed block or manual
+  section that tells the agent to read `.tree-ring/AGENTS.md`,
+  `.tree-ring/SKILL.md`, and `.tree-ring/CLI.md`.
+- Pi: a `.pi/settings.json` resource path that points at the Tree Ring skill or
+  CLI guidance.
+
+Project bridge files are preferred because they stay scoped to the current
+repo. Global bridge files under `~/.agents`, `~/.codex`, `~/.claude`,
+`~/.gemini`, or `~/.pi` affect every project and should be written only through
+an explicit global opt-in flow.
+
+The bridge-linking design is agent-mediated: bridge files teach the active
+agent when to call Tree Ring, but Tree Ring does not run a background recorder
+or autonomously persist chat transcripts. Durable writes happen only when a
+user, agent, adapter, import, TUI action, consolidation command, or explicit
+maintenance command calls the CLI.
+
+`tree-ring integrations scan --source-root .` is read-only today. The planned
+`tree-ring integrations link --scope project --harness auto --dry-run` command
+will preview bridge writes first, then write only missing files or safe managed
+blocks. Until that command is implemented, add the bridge references manually.
 
 ## Safety Rule
 

--- a/docs/superpowers/specs/2026-07-05-tree-ring-memory-installer-onboarding-v0-10-design.md
+++ b/docs/superpowers/specs/2026-07-05-tree-ring-memory-installer-onboarding-v0-10-design.md
@@ -34,14 +34,28 @@ blocking wizard.
 Default:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/TerminallyLazy/Tree-Ring-Memory/main/install.sh | sh
+(
+  installer=$(mktemp) &&
+  trap 'rm -f "$installer"' EXIT &&
+  curl -fsSL https://raw.githubusercontent.com/TerminallyLazy/Tree-Ring-Memory/main/install.sh -o "$installer" &&
+  sh "$installer"
+)
 ```
 
 Project-local:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/TerminallyLazy/Tree-Ring-Memory/main/install.sh | sh -s -- --project --init
+(
+  installer=$(mktemp) &&
+  trap 'rm -f "$installer"' EXIT &&
+  curl -fsSL https://raw.githubusercontent.com/TerminallyLazy/Tree-Ring-Memory/main/install.sh -o "$installer" &&
+  sh "$installer" --project --init
+)
 ```
+
+The temporary file holds only the downloaded installer script. The cleanup trap
+removes that script after the subshell exits; persistent memory remains in the
+configured memory root.
 
 Emotional arc:
 

--- a/docs/superpowers/specs/2026-07-05-tree-ring-memory-installer-onboarding-v0-10-design.md
+++ b/docs/superpowers/specs/2026-07-05-tree-ring-memory-installer-onboarding-v0-10-design.md
@@ -36,7 +36,7 @@ Default:
 ```bash
 (
   installer=$(mktemp) &&
-  trap 'rm -f "$installer"' EXIT &&
+  trap 'rm -f "$installer"' EXIT INT TERM &&
   curl -fsSL https://raw.githubusercontent.com/TerminallyLazy/Tree-Ring-Memory/main/install.sh -o "$installer" &&
   sh "$installer"
 )
@@ -47,15 +47,15 @@ Project-local:
 ```bash
 (
   installer=$(mktemp) &&
-  trap 'rm -f "$installer"' EXIT &&
+  trap 'rm -f "$installer"' EXIT INT TERM &&
   curl -fsSL https://raw.githubusercontent.com/TerminallyLazy/Tree-Ring-Memory/main/install.sh -o "$installer" &&
   sh "$installer" --project --init
 )
 ```
 
 The temporary file holds only the downloaded installer script. The cleanup trap
-removes that script after the subshell exits; persistent memory remains in the
-configured memory root.
+removes that script after the subshell exits or receives `INT`/`TERM`;
+persistent memory remains in the configured memory root.
 
 Emotional arc:
 

--- a/install.sh
+++ b/install.sh
@@ -44,8 +44,18 @@ usage() {
 Tree Ring Memory installer
 
 Usage:
-  installer=$(mktemp) && curl -fsSL https://raw.githubusercontent.com/TerminallyLazy/Tree-Ring-Memory/main/install.sh -o "$installer" && sh "$installer"
-  installer=$(mktemp) && curl -fsSL https://raw.githubusercontent.com/TerminallyLazy/Tree-Ring-Memory/main/install.sh -o "$installer" && sh "$installer" --project --init
+  (
+    installer=$(mktemp) &&
+    trap 'rm -f "$installer"' EXIT &&
+    curl -fsSL https://raw.githubusercontent.com/TerminallyLazy/Tree-Ring-Memory/main/install.sh -o "$installer" &&
+    sh "$installer"
+  )
+  (
+    installer=$(mktemp) &&
+    trap 'rm -f "$installer"' EXIT &&
+    curl -fsSL https://raw.githubusercontent.com/TerminallyLazy/Tree-Ring-Memory/main/install.sh -o "$installer" &&
+    sh "$installer" --project --init
+  )
 
 Options:
   --global              Install to $HOME/.local/bin (default).

--- a/install.sh
+++ b/install.sh
@@ -46,13 +46,13 @@ Tree Ring Memory installer
 Usage:
   (
     installer=$(mktemp) &&
-    trap 'rm -f "$installer"' EXIT &&
+    trap 'rm -f "$installer"' EXIT INT TERM &&
     curl -fsSL https://raw.githubusercontent.com/TerminallyLazy/Tree-Ring-Memory/main/install.sh -o "$installer" &&
     sh "$installer"
   )
   (
     installer=$(mktemp) &&
-    trap 'rm -f "$installer"' EXIT &&
+    trap 'rm -f "$installer"' EXIT INT TERM &&
     curl -fsSL https://raw.githubusercontent.com/TerminallyLazy/Tree-Ring-Memory/main/install.sh -o "$installer" &&
     sh "$installer" --project --init
   )

--- a/skills/tree-ring-memory/SKILL.md
+++ b/skills/tree-ring-memory/SKILL.md
@@ -87,6 +87,12 @@ tree-ring evidence --help
 If the project was initialized with a project-local binary, prefer the generated
 `.tree-ring/CLI.md` reference and include `--root .tree-ring` when needed.
 
+If this skill was loaded through a harness-native bridge file, treat that bridge
+as a pointer only. Read the project-local `.tree-ring/SKILL.md` and
+`.tree-ring/CLI.md` when present so commands match the installed project root.
+Do not assume a global Tree Ring setup applies to the current repo unless the
+user explicitly configured it.
+
 Evidence outcome mapping:
 
 - `promoted`: durable heartwood from supported evidence
@@ -157,6 +163,22 @@ Memory does not replace source documents. If a repo has `AGENTS.md`, project doc
 When DOX or Revolve source records change, re-run the matching sync adapter with
 `--dry-run`, inspect the generated memories, then run the write command only
 when the summaries are useful and source-linked.
+
+## Agent-Mediated Updates
+
+Tree Ring Memory does not autonomously scrape chats or write durable memory in
+the background. The active agent is responsible for deciding when a Tree Ring
+command is warranted, then calling the CLI deliberately.
+
+Use bridge files only to discover Tree Ring and its command reference:
+
+- project-level bridges should point to `.tree-ring/SKILL.md` and
+  `.tree-ring/CLI.md`
+- global bridges should be treated as opt-in user configuration
+- TUI event-stream pulses are display signals, not durable memories
+
+Before writing memory, verify the lesson is durable, useful, privacy-safe, and
+grounded in user instruction or source evidence.
 
 ## Forgetting And Correction
 

--- a/templates/dox/AGENTS.md
+++ b/templates/dox/AGENTS.md
@@ -18,6 +18,11 @@ Default local memory path:
 
 Do not commit local memory databases or exports unless the project explicitly requires sanitized fixtures.
 
+Harness-native bridge files should point agents back to this memory root's
+generated guidance instead of duplicating memory data. Prefer project-level
+bridges for the current repo. Treat global Tree Ring bridges as explicit user
+configuration that affects every project.
+
 ## Recall Rules
 
 Before substantial work, recall project-scoped memory for:
@@ -60,6 +65,14 @@ tree-ring integrations scan --source-root .
 
 Run adapter syncs as previews first. Persist only concise, source-linked
 summaries that help future recall.
+
+## Agent-Mediated Updates
+
+Tree Ring Memory writes durable memories only when a user, agent, adapter,
+import, TUI action, consolidation command, or explicit maintenance command calls
+the CLI. It must not be used as a hidden transcript recorder. Bridge files tell
+the active agent when to call Tree Ring; they do not authorize autonomous
+background capture.
 
 ## Ring Mapping
 


### PR DESCRIPTION
## Summary
- Update README installer snippets to use a temporary installer file with subshell cleanup
- Document that the temp file is only the downloaded installer and does not remove memory, binaries, caches, source checkouts, or profiles
- Expand README, integration docs, generated Tree Ring guidance, portable skill, DOX template, and architecture status with project/global bridge guidance and agent-mediated memory behavior

## Verification
- git diff --check
- sh install.sh --help
- cargo test --locked -p tree-ring-memory-cli agent_awareness
- cargo test --locked -p tree-ring-memory-cli

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved installation guidance with safer temporary-file examples instead of piping scripts directly into `sh`.
  * Added clearer notes about where temporary files are used and when they are cleaned up.
  * Expanded guidance for agent and harness setup, including bridge-file pointers, recommended bridge locations, and how memory updates should be triggered.
  * Clarified current integration behavior and added a reference to the related design document.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->