### PR TITLE
Update checkout workflows to Node 24 runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
## What changed

- Update `actions/checkout` from `v4` to `v5` in CI and release workflows.

## Why

GitHub's post-merge run for PR #38 succeeded but emitted a deprecation annotation because checkout v4 targets Node 20 and is being force-run on Node 24. Checkout v5 is the official minimal migration to the Node 24 runtime.

## Impact

CI and release jobs keep the same checkout behavior while using the supported runtime. This also keeps both workflow files aligned.

## Validation

- Both workflow YAML files parse successfully.
- `git diff --check` passes.
- The branch contains only the two checkout-version changes.
- PR CI will exercise the updated action on GitHub-hosted runners before merge.