### PR TITLE
ci: harden release artifact checksums

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
         run: sh scripts/package-release.sh
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: tree-ring-memory-${{ matrix.os }}
           path: |

--- a/scripts/package-release.sh
+++ b/scripts/package-release.sh
@@ -12,6 +12,7 @@ ARCH=$(uname -m | tr '[:upper:]' '[:lower:]')
 NAME="tree-ring-memory-$VERSION-$OS-$ARCH"
 DIST_DIR=${TREE_RING_DIST_DIR:-dist}
 WORK_DIR="$DIST_DIR/$NAME"
+ARCHIVE="$NAME.tar.gz"
 
 rm -rf "$WORK_DIR"
 mkdir -p "$WORK_DIR"
@@ -21,14 +22,22 @@ cargo build --release -p tree-ring-memory-cli --locked
 cp target/release/tree-ring "$WORK_DIR/tree-ring"
 cp README.md LICENSE install.sh "$WORK_DIR/"
 
-tar -C "$DIST_DIR" -czf "$DIST_DIR/$NAME.tar.gz" "$NAME"
+tar -C "$DIST_DIR" -czf "$DIST_DIR/$ARCHIVE" "$NAME"
 
 if command -v shasum >/dev/null 2>&1; then
-  shasum -a 256 "$DIST_DIR/$NAME.tar.gz" > "$DIST_DIR/$NAME.tar.gz.sha256"
+  (
+    cd "$DIST_DIR"
+    shasum -a 256 "$ARCHIVE" > "$ARCHIVE.sha256"
+    shasum -a 256 -c "$ARCHIVE.sha256"
+  )
 elif command -v sha256sum >/dev/null 2>&1; then
-  sha256sum "$DIST_DIR/$NAME.tar.gz" > "$DIST_DIR/$NAME.tar.gz.sha256"
+  (
+    cd "$DIST_DIR"
+    sha256sum "$ARCHIVE" > "$ARCHIVE.sha256"
+    sha256sum -c "$ARCHIVE.sha256"
+  )
 else
   printf '%s\n' "warning: no SHA-256 tool found; checksum not written" >&2
 fi
 
-printf 'release_package=%s\n' "$DIST_DIR/$NAME.tar.gz"
+printf 'release_package=%s\n' "$DIST_DIR/$ARCHIVE"


### PR DESCRIPTION
## Summary

Follow up on the verified v0.13.0 tag run:

- generate checksum manifests from inside the distribution directory so downloaded artifacts use portable basenames rather than a stripped `dist/` path
- verify each checksum manifest during packaging
- update the artifact upload action to the current Node runtime

The published v0.13.0 release assets were independently normalized and verified; this change prevents the workflow quirk in future releases.

## Validation

- `sh -n scripts/package-release.sh`
- release workflow YAML parse
- isolated `TREE_RING_DIST_DIR` package run
- generated checksum passes `shasum -a 256 -c` after download-style flattening
- `git diff --check`