### PR TITLE
ci: build Linux releases on Bookworm

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,28 +5,82 @@ on:
     tags:
       - "v*"
   workflow_dispatch:
+    inputs:
+      source_ref:
+        description: Git ref to package (for example, v0.13.0)
+        required: false
+        type: string
 
 jobs:
-  package:
-    name: Package ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest, macos-latest]
-    runs-on: ${{ matrix.os }}
+  package-linux:
+    name: Package ubuntu-latest
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+        with:
+          ref: ${{ inputs.source_ref || github.ref }}
+
+      - name: Build package on Debian Bookworm
+        env:
+          RUST_BOOKWORM_IMAGE: docker.io/library/rust:1.89-bookworm@sha256:c9ac3fa8945b61dede1e4500d25028aa8fd8a8fe46365fcf9c0422f8d999b9b0
+        run: |
+          docker run --rm \
+            --platform linux/amd64 \
+            --user "$(id -u):$(id -g)" \
+            -e HOME=/tmp \
+            -e CARGO_HOME=/tmp/cargo \
+            -e RUSTUP_HOME=/usr/local/rustup \
+            -v "$GITHUB_WORKSPACE:/workspace" \
+            -w /workspace \
+            "$RUST_BOOKWORM_IMAGE" \
+            sh -c 'sh scripts/package-release.sh'
+
+      - name: Smoke-test package on Debian Bookworm
+        env:
+          DEBIAN_BOOKWORM_IMAGE: docker.io/library/debian:bookworm-slim@sha256:63a496b5d3b99214b39f5ed70eb71a61e590a77979c79cbee4faf991f8c0783e
+        run: |
+          linux_binary=$(
+            find "$GITHUB_WORKSPACE/dist" \
+              -path '*-linux-x86_64/tree-ring' \
+              -type f \
+              -print
+          )
+          test -n "$linux_binary"
+          test "$(printf '%s\n' "$linux_binary" | wc -l)" -eq 1
+          docker run --rm \
+            --platform linux/amd64 \
+            -v "$linux_binary:/tree-ring:ro" \
+            "$DEBIAN_BOOKWORM_IMAGE" \
+            /tree-ring --version
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: tree-ring-memory-ubuntu-latest
+          path: |
+            dist/*.tar.gz
+            dist/*.sha256
+
+  package-macos:
+    name: Package macos-latest
+    runs-on: macos-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+        with:
+          ref: ${{ inputs.source_ref || github.ref }}
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
 
       - name: Build package
         run: sh scripts/package-release.sh
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
-          name: tree-ring-memory-${{ matrix.os }}
+          name: tree-ring-memory-macos-latest
           path: |
             dist/*.tar.gz
             dist/*.sha256

--- a/README.md
+++ b/README.md
@@ -643,7 +643,9 @@ interpretation limits.
 
 `scripts/package-release.sh` builds the Rust CLI in release mode, creates a
 platform tarball under `dist/`, and writes a SHA-256 checksum file. Tag pushes
-run the release artifact workflow for Linux and macOS.
+run the release artifact workflow for Linux and macOS. Linux x86_64 artifacts
+are built and executed on Debian Bookworm (glibc 2.36); older glibc systems
+must build from source.
 
 ## Design Docs
 


### PR DESCRIPTION
## Problem
The public v0.13.0 Linux x86_64 archive was built on ubuntu-latest and requires GLIBC 2.39. Executing that artifact on Debian Bookworm fails before startup because Bookworm provides GLIBC 2.36.

## Fix
- build Linux release archives in an immutable amd64 Rust 1.89 / Debian Bookworm image
- execute the packaged binary in an immutable Debian Bookworm runtime before upload
- allow manual release rebuilds to checkout an explicit source ref such as v0.13.0
- pin release-workflow actions and container images by commit or digest
- document the glibc 2.36 binary baseline

## Validation
- reproduced the public artifact failure on Bookworm
- built v0.13.0 locally in the pinned amd64 Bookworm image
- verified archive checksum
- executed version, help, init, agent-scoped remember, exact retry, and filtered recall in the pinned Bookworm runtime
- actionlint 1.7.7 passed
- YAML and diff checks passed