### PR TITLE
docs: clarify source and binary install paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,10 +97,18 @@ guidance.
 
 ## Quick Start
 
-Global user install:
+Source install (requires Rust and Cargo):
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/TerminallyLazy/Tree-Ring-Memory/main/install.sh | sh
+```
+
+Linux x86_64 prebuilt install (glibc 2.36 or newer):
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/TerminallyLazy/Tree-Ring-Memory/main/install.sh | sh -s -- \
+  --archive-url https://github.com/TerminallyLazy/Tree-Ring-Memory/releases/download/v0.13.0/tree-ring-memory-0.13.0-linux-x86_64.tar.gz \
+  --archive-sha256 76966ec89990c0d10ab933733b1d0f601beec343cb90b64ee7f0655672b10a6a
 ```
 
 macOS ARM64 install with Homebrew:
@@ -110,7 +118,7 @@ brew tap TerminallyLazy/tree-ring
 brew install tree-ring
 ```
 
-Project-local install with first-run initialization:
+Project-local source install with first-run initialization (requires Cargo):
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/TerminallyLazy/Tree-Ring-Memory/main/install.sh | sh -s -- --project --init

--- a/docs/index.html
+++ b/docs/index.html
@@ -436,8 +436,13 @@
           <li>Feedback flows through GitHub issue #26.</li>
         </ul>
       </div>
-      <pre><code># Portable installer
+      <pre><code># Source install (requires Rust and Cargo)
 curl -fsSL https://raw.githubusercontent.com/TerminallyLazy/Tree-Ring-Memory/main/install.sh | sh
+
+# Linux x86_64 prebuilt (glibc 2.36+)
+curl -fsSL https://raw.githubusercontent.com/TerminallyLazy/Tree-Ring-Memory/main/install.sh | sh -s -- \
+  --archive-url https://github.com/TerminallyLazy/Tree-Ring-Memory/releases/download/v0.13.0/tree-ring-memory-0.13.0-linux-x86_64.tar.gz \
+  --archive-sha256 76966ec89990c0d10ab933733b1d0f601beec343cb90b64ee7f0655672b10a6a
 
 # macOS ARM64 Homebrew tap
 brew tap TerminallyLazy/tree-ring

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -37,10 +37,18 @@ ideas stay as seeds.
 - Read-only agent-framework discovery.
 - Terminal onboarding and a Ratatui operator console.
 
-## Install
+## Install From Source (Requires Rust and Cargo)
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/TerminallyLazy/Tree-Ring-Memory/main/install.sh | sh
+```
+
+Linux x86_64 prebuilt install (glibc 2.36 or newer):
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/TerminallyLazy/Tree-Ring-Memory/main/install.sh | sh -s -- \
+  --archive-url https://github.com/TerminallyLazy/Tree-Ring-Memory/releases/download/v0.13.0/tree-ring-memory-0.13.0-linux-x86_64.tar.gz \
+  --archive-sha256 76966ec89990c0d10ab933733b1d0f601beec343cb90b64ee7f0655672b10a6a
 ```
 
 macOS ARM64 Homebrew install:


### PR DESCRIPTION
## Summary
- state that the default installer compiles from source and requires Rust/Cargo
- add the verified Linux x86_64 prebuilt install command and current SHA-256
- publish the same truthful guidance in README, llms.txt, and the launch page

## Validation
- executed the documented public archive install on Debian Bookworm
- verified v0.13.0 version, init, agent-scoped write, and filtered recall
- SHA appears consistently on all three surfaces
- git diff check passed