### PR TITLE
Docs: refresh public v0.14 release references

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ framework-agnostic and does not replace either protocol.
 Tree Ring Memory is in protocol-preview status. Current launch links:
 
 - Launch page: <https://terminallylazy.github.io/Tree-Ring-Memory/>
-- Launch release: <https://github.com/TerminallyLazy/Tree-Ring-Memory/releases/tag/v0.13.0>
+- Launch release: <https://github.com/TerminallyLazy/Tree-Ring-Memory/releases/tag/v0.14.0>
 - Launch discussion: <https://github.com/TerminallyLazy/Tree-Ring-Memory/discussions/27>
 - Rust-native CLI article: <https://terminallylazy.github.io/Tree-Ring-Memory/launch/rust-native-agent-memory-cli.md>
 - Feedback issue: <https://github.com/TerminallyLazy/Tree-Ring-Memory/issues/26>
@@ -39,6 +39,7 @@ Tree Ring Memory is in protocol-preview status. Current launch links:
 - v0.11 made the repo fully Rust-native, wired TUI export/consolidation actions, added DOX/Revolve sync adapters, and added agent-framework discovery.
 - v0.12 adds a controlled, retained agent-workflow proof with explicit model identity and exact structured-output checks; it reports observed outcomes without claiming a universal memory advantage.
 - v0.13 adds same-host multi-agent identities and idempotency, opt-in coordinator authorization for shared writes, a protected-write audit, and a schema-v3 fence for old memory inserts, updates, and deletes.
+- v0.14 adds project-local harness activation with receipt-backed readiness, so configured bridges do not imply that an agent has used memory.
 
 </details>
 
@@ -153,8 +154,8 @@ Linux x86_64 prebuilt install (glibc 2.36 or newer):
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/TerminallyLazy/Tree-Ring-Memory/main/install.sh | sh -s -- \
-  --archive-url https://github.com/TerminallyLazy/Tree-Ring-Memory/releases/download/v0.13.0/tree-ring-memory-0.13.0-linux-x86_64.tar.gz \
-  --archive-sha256 76966ec89990c0d10ab933733b1d0f601beec343cb90b64ee7f0655672b10a6a
+  --archive-url https://github.com/TerminallyLazy/Tree-Ring-Memory/releases/download/v0.14.0/tree-ring-memory-0.14.0-linux-x86_64.tar.gz \
+  --archive-sha256 c72191aca81f195472272a1962df354fe0af04a08b01a7472a1faf987cd177fa
 ```
 
 macOS ARM64 install with Homebrew:
@@ -224,7 +225,7 @@ sh install.sh --project --init
 sh install.sh --global --install-dir "$HOME/.local"
 sh install.sh --no-animation  # stable output; kept for explicit script usage
 sh install.sh --no-path-update
-sh install.sh --archive-url https://example/tree-ring-memory-0.13.0-darwin-arm64.tar.gz --archive-sha256 <sha256>
+sh install.sh --archive-url https://example/tree-ring-memory-0.14.0-darwin-arm64.tar.gz --archive-sha256 <sha256>
 ```
 
 After install, rerun onboarding anytime:

--- a/docs/architecture/rust-core-status.md
+++ b/docs/architecture/rust-core-status.md
@@ -10,7 +10,9 @@ v0.11 Rust-native source adapters plus framework discovery. The v0.12 line now
 also carries explicit same-host multi-agent correlation, partitioning, and
 idempotent-write semantics. The v0.13 line adds an opt-in coordinated write
 policy, protected-write audit, schema-v3 old-memory-mutation fence, and
-forward-schema rejection.
+forward-schema rejection. The v0.14 line adds project-local harness activation
+with receipt-backed readiness, keeping configured bridges distinct from active
+memory use.
 
 ## Current Status
 

--- a/docs/feed.xml
+++ b/docs/feed.xml
@@ -5,11 +5,19 @@
   <id>https://terminallylazy.github.io/Tree-Ring-Memory/</id>
   <link href="https://terminallylazy.github.io/Tree-Ring-Memory/" rel="alternate"/>
   <link href="https://terminallylazy.github.io/Tree-Ring-Memory/feed.xml" rel="self"/>
-  <updated>2026-07-23T20:26:15Z</updated>
+  <updated>2026-08-14T08:25:58Z</updated>
   <author>
     <name>Tree Ring Memory</name>
     <uri>https://github.com/TerminallyLazy/Tree-Ring-Memory</uri>
   </author>
+
+  <entry>
+    <title>Tree Ring Memory v0.14.0 adds receipt-backed harness activation</title>
+    <id>https://github.com/TerminallyLazy/Tree-Ring-Memory/releases/tag/v0.14.0</id>
+    <link href="https://github.com/TerminallyLazy/Tree-Ring-Memory/releases/tag/v0.14.0"/>
+    <updated>2026-08-14T08:25:58Z</updated>
+    <summary>Tree Ring Memory v0.14.0 adds project-local harness activation with adapter preflight and receipt-backed status, so configured bridges do not imply that an agent has used memory. Agent Zero remains passive until its separately installed plugin provides its capability and writes a fresh receipt.</summary>
+  </entry>
 
   <entry>
     <title>Tree Ring Memory v0.13.0 adds same-host multi-agent guardrails</title>

--- a/docs/index.html
+++ b/docs/index.html
@@ -28,7 +28,7 @@
       "programmingLanguage": "Rust",
       "applicationCategory": "DeveloperApplication",
       "operatingSystem": "macOS, Linux",
-      "version": "0.13.0",
+      "version": "0.14.0",
       "image": "https://terminallylazy.github.io/Tree-Ring-Memory/assets/tree-ring-memory-og.png",
       "isAccessibleForFree": true
     }
@@ -441,8 +441,8 @@ curl -fsSL https://raw.githubusercontent.com/TerminallyLazy/Tree-Ring-Memory/mai
 
 # Linux x86_64 prebuilt (glibc 2.36+)
 curl -fsSL https://raw.githubusercontent.com/TerminallyLazy/Tree-Ring-Memory/main/install.sh | sh -s -- \
-  --archive-url https://github.com/TerminallyLazy/Tree-Ring-Memory/releases/download/v0.13.0/tree-ring-memory-0.13.0-linux-x86_64.tar.gz \
-  --archive-sha256 76966ec89990c0d10ab933733b1d0f601beec343cb90b64ee7f0655672b10a6a
+  --archive-url https://github.com/TerminallyLazy/Tree-Ring-Memory/releases/download/v0.14.0/tree-ring-memory-0.14.0-linux-x86_64.tar.gz \
+  --archive-sha256 c72191aca81f195472272a1962df354fe0af04a08b01a7472a1faf987cd177fa
 
 # macOS ARM64 Homebrew tap
 brew tap TerminallyLazy/tree-ring

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -5,14 +5,14 @@
 
 Website: https://terminallylazy.github.io/Tree-Ring-Memory/
 Repository: https://github.com/TerminallyLazy/Tree-Ring-Memory
-Launch release: https://github.com/TerminallyLazy/Tree-Ring-Memory/releases/tag/v0.13.0
+Launch release: https://github.com/TerminallyLazy/Tree-Ring-Memory/releases/tag/v0.14.0
 Launch discussion: https://github.com/TerminallyLazy/Tree-Ring-Memory/discussions/27
 Homebrew tap: https://github.com/TerminallyLazy/homebrew-tree-ring
 Feedback: https://github.com/TerminallyLazy/Tree-Ring-Memory/issues/26
 Feed: https://terminallylazy.github.io/Tree-Ring-Memory/feed.xml
 License: MIT
 Status: protocol-preview
-Current version: 0.13.0
+Current version: 0.14.0
 
 ## Summary
 
@@ -33,6 +33,7 @@ ideas stay as seeds.
 - Controlled workflow-proof artifacts with explicit model identity and exact structured-output checks.
 - Same-host multi-agent identity, scoped recall, and exact-retry idempotency.
 - Optional coordinator authorization for shared writes and lifecycle mutations.
+- Project-local harness activation with receipt-backed readiness.
 - DOX and Revolve sync adapters.
 - Read-only agent-framework discovery.
 - Terminal onboarding and a Ratatui operator console.
@@ -47,8 +48,8 @@ Linux x86_64 prebuilt install (glibc 2.36 or newer):
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/TerminallyLazy/Tree-Ring-Memory/main/install.sh | sh -s -- \
-  --archive-url https://github.com/TerminallyLazy/Tree-Ring-Memory/releases/download/v0.13.0/tree-ring-memory-0.13.0-linux-x86_64.tar.gz \
-  --archive-sha256 76966ec89990c0d10ab933733b1d0f601beec343cb90b64ee7f0655672b10a6a
+  --archive-url https://github.com/TerminallyLazy/Tree-Ring-Memory/releases/download/v0.14.0/tree-ring-memory-0.14.0-linux-x86_64.tar.gz \
+  --archive-sha256 c72191aca81f195472272a1962df354fe0af04a08b01a7472a1faf987cd177fa
 ```
 
 macOS ARM64 Homebrew install:
@@ -90,7 +91,7 @@ writes are explicit.
 - Rust article: https://terminallylazy.github.io/Tree-Ring-Memory/launch/rust-native-agent-memory-cli.md
 - Press kit: https://terminallylazy.github.io/Tree-Ring-Memory/press-kit.md
 - Repository: https://github.com/TerminallyLazy/Tree-Ring-Memory
-- Launch release: https://github.com/TerminallyLazy/Tree-Ring-Memory/releases/tag/v0.13.0
+- Launch release: https://github.com/TerminallyLazy/Tree-Ring-Memory/releases/tag/v0.14.0
 - Launch discussion: https://github.com/TerminallyLazy/Tree-Ring-Memory/discussions/27
 - Homebrew tap: https://github.com/TerminallyLazy/homebrew-tree-ring
 - Feedback issue: https://github.com/TerminallyLazy/Tree-Ring-Memory/issues/26

--- a/docs/press-kit.md
+++ b/docs/press-kit.md
@@ -23,10 +23,10 @@ DOX/Revolve adapters, framework discovery, and a terminal TUI.
 - Category: AI agents, developer tools, local-first software, Rust CLI
 - License: MIT
 - Status: protocol-preview
-- Current version: 0.13.0
+- Current version: 0.14.0
 - Website: <https://terminallylazy.github.io/Tree-Ring-Memory/>
 - Repository: <https://github.com/TerminallyLazy/Tree-Ring-Memory>
-- Launch release: <https://github.com/TerminallyLazy/Tree-Ring-Memory/releases/tag/v0.13.0>
+- Launch release: <https://github.com/TerminallyLazy/Tree-Ring-Memory/releases/tag/v0.14.0>
 - Launch discussion: <https://github.com/TerminallyLazy/Tree-Ring-Memory/discussions/27>
 - Homebrew tap: <https://github.com/TerminallyLazy/homebrew-tree-ring>
 - Feedback: <https://github.com/TerminallyLazy/Tree-Ring-Memory/issues/26>
@@ -47,6 +47,7 @@ Agent memory should age, not pile up.
 - Controlled workflow-proof artifacts with explicit model identity and exact structured-output checks.
 - Same-host multi-agent identity, scoped recall, and exact-retry idempotency.
 - Optional coordinator authorization for shared writes and lifecycle mutations.
+- Project-local harness activation with receipt-backed readiness.
 - DOX and Revolve sync adapters.
 - Terminal onboarding and Ratatui operator console.
 

--- a/marketing/README.md
+++ b/marketing/README.md
@@ -309,7 +309,7 @@ python3 marketing/scripts/build-campaign-cards.py
 
 - Repository: `https://github.com/TerminallyLazy/Tree-Ring-Memory`
 - Launch page: `https://terminallylazy.github.io/Tree-Ring-Memory/`
-- Launch release: `https://github.com/TerminallyLazy/Tree-Ring-Memory/releases/tag/v0.13.0`
+- Launch release: `https://github.com/TerminallyLazy/Tree-Ring-Memory/releases/tag/v0.14.0`
 - Launch discussion: `https://github.com/TerminallyLazy/Tree-Ring-Memory/discussions/27`
 - Homebrew tap: `https://github.com/TerminallyLazy/homebrew-tree-ring`
 - Agent-Skills.md main repo listing:

--- a/skills/tree-ring-memory/SKILL.md
+++ b/skills/tree-ring-memory/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: tree-ring-memory
 description: Guides AI agents in using Tree Ring Memory for durable recall, project decisions, user preferences, warnings, future seeds, privacy-safe memory capture, and lifecycle-aware forgetting.
-version: 0.13.0
+version: 0.14.0
 tags: ["memory", "agents", "recall", "privacy", "projects", "dox", "revolve", "skills", "cli"]
 triggers:
   - "remember this"


### PR DESCRIPTION
Refreshes public release links, archive checksum, feed, metadata, and skill references for the published Tree Ring v0.14.0 release.\n\nValidated: diff check, stale-pointer scan, and XML validation.