### PR TITLE
fix: address plugin security review

### DIFF
--- a/README.md
+++ b/README.md
@@ -407,7 +407,8 @@ existing memory, explicitly enable Coordinated mode:
 
 ```bash
 tree-ring --root .tree-ring policy enable --coordinator release-coordinator
-export TREE_RING_COORDINATOR_TOKEN='<one-time capability printed by enable>'
+# Set and export TREE_RING_COORDINATOR_TOKEN with a history-safe, no-echo prompt
+# supported by your shell, or inject it through an approved secret manager.
 tree-ring --root .tree-ring policy status
 tree-ring --root .tree-ring policy audit --limit 100
 ```
@@ -416,7 +417,9 @@ Enable prints the coordinator capability once. Put it only in
 `TREE_RING_COORDINATOR_TOKEN`; never pass it as a CLI flag or retain it in
 memory events, logs, source refs, scripts, or committed files. Tree Ring stores
 only a hash. `policy status` and `policy audit` are read-only and never reveal
-the capability. Inject the variable only into coordinator processes; explicitly
+the capability. Do not paste it into an `export` command; use a history-safe,
+no-echo prompt supported by the current shell or approved secret-manager
+injection. Inject the variable only into coordinator processes; explicitly
 remove it from every ordinary worker's environment so fan-out children cannot
 inherit coordinator authority.
 
@@ -441,7 +444,8 @@ replace the environment value with the newly printed capability:
 
 ```bash
 tree-ring --root .tree-ring policy rotate --coordinator release-coordinator-next
-export TREE_RING_COORDINATOR_TOKEN='<new one-time capability>'
+# Replace TREE_RING_COORDINATOR_TOKEN through the same history-safe, no-echo
+# input path before using the new capability.
 tree-ring --root .tree-ring policy disable
 unset TREE_RING_COORDINATOR_TOKEN
 ```

--- a/crates/tree-ring-memory-cli/src/agent_awareness.rs
+++ b/crates/tree-ring-memory-cli/src/agent_awareness.rs
@@ -95,7 +95,7 @@ Multi-agent coordination:
 Coordinated write policy:
 
 - Stores remain in backward-compatible Open mode until a coordinator explicitly runs `tree-ring policy enable --coordinator <label>`.
-- Enable and rotate print a one-time capability. Put it only in `TREE_RING_COORDINATOR_TOKEN`; there is no token CLI flag, and Tree Ring never stores the plaintext capability. Inject it only into coordinator processes and keep it unset for ordinary workers.
+- Enable and rotate print a one-time capability. Put it only in `TREE_RING_COORDINATOR_TOKEN`; there is no token CLI flag, and Tree Ring never stores the plaintext capability. Do not paste it into an `export` command; set it with a history-safe, no-echo prompt supported by the current shell or approved secret-manager injection. Inject it only into coordinator processes and keep it unset for ordinary workers.
 - In Coordinated mode, an ordinary worker may create only non-heartwood `scope=agent` memory whose `agent_profile` matches its `--agent-profile` or `TREE_RING_AGENT_PROFILE`.
 - Shared or non-agent writes, heartwood, imports, DOX/Revolve persistence, consolidation, ring changes, supersede/delete/redact, and applied maintenance require the coordinator capability.
 - `tree-ring policy status` and `tree-ring policy audit --limit 100` are read-only. Rotate with `tree-ring policy rotate --coordinator <label>` and return to Open mode with `tree-ring policy disable`; both require the current capability.
@@ -393,19 +393,24 @@ into Coordinated mode:
 
 ```bash
 tree-ring --root {root} policy enable --coordinator release-coordinator
-export TREE_RING_COORDINATOR_TOKEN='<one-time capability printed by enable>'
+# Set and export TREE_RING_COORDINATOR_TOKEN with a history-safe, no-echo prompt
+# supported by your shell, or inject it through an approved secret manager.
 tree-ring --root {root} policy status
 tree-ring --root {root} policy audit --limit 100
 tree-ring --root {root} policy rotate --coordinator release-coordinator-next
+# Replace TREE_RING_COORDINATOR_TOKEN through the same history-safe, no-echo
+# input path before using the new capability.
 tree-ring --root {root} policy disable
 unset TREE_RING_COORDINATOR_TOKEN
 ```
 
 Replace the environment value with the new one-time capability immediately
 after rotation. Never pass the capability as a CLI flag or retain it in memory
-events, logs, source refs, or committed files. Tree Ring stores only its hash.
-Inject the variable only into coordinator processes, and keep it unset in every
-ordinary worker environment.
+events, logs, source refs, or committed files. Do not paste it into an `export`
+command; use a history-safe, no-echo prompt supported by the current shell or
+approved secret-manager injection. Tree Ring stores only its hash. Inject the
+variable only into coordinator processes, and keep it unset in every ordinary
+worker environment.
 
 In Coordinated mode, an ordinary worker may create only non-heartwood
 `scope=agent` memory whose `agent_profile` matches the write context supplied by
@@ -566,6 +571,7 @@ mod tests {
         assert!(agents.contains("Coordinated Write Policy"));
         assert!(agents.contains("policy enable --coordinator"));
         assert!(agents.contains("TREE_RING_COORDINATOR_TOKEN"));
+        assert!(agents.contains("history-safe, no-echo"));
         assert!(agents.contains("ordinary worker may create only non-heartwood"));
         assert!(agents.contains("schema v3"));
         assert!(agents.contains("not a read ACL"));
@@ -601,6 +607,7 @@ mod tests {
         assert!(cli.contains("Coordinated write policy"));
         assert!(cli.contains("policy enable --coordinator"));
         assert!(cli.contains("TREE_RING_COORDINATOR_TOKEN"));
+        assert!(cli.contains("history-safe, no-echo"));
         assert!(cli.contains("memory inserts, updates, and deletes from old v0.12 writers"));
         assert!(cli.contains("Before substantial project work, recall project constraints, scars, user preferences, and unresolved seeds."));
         assert!(cli
@@ -731,6 +738,7 @@ mod tests {
         assert!(agents.contains("TREE_RING_COORDINATOR_TOKEN"));
         assert!(cli.contains("ordinary worker may create only non-heartwood"));
         assert!(skill.contains("policy enable --coordinator"));
+        assert!(cli.contains("history-safe, no-echo"));
     }
 
     #[test]

--- a/docs/integrations/agent-skill.md
+++ b/docs/integrations/agent-skill.md
@@ -186,15 +186,18 @@ should publish only to their own agent partitions:
 
 ```bash
 tree-ring --root .tree-ring policy enable --coordinator release-coordinator
-export TREE_RING_COORDINATOR_TOKEN='<one-time capability printed by enable>'
+# Set and export TREE_RING_COORDINATOR_TOKEN with a history-safe, no-echo prompt
+# supported by your shell, or inject it through an approved secret manager.
 tree-ring --root .tree-ring policy status
 tree-ring --root .tree-ring policy audit --limit 100
 ```
 
 Enable prints the capability exactly once. Supply it only through
 `TREE_RING_COORDINATOR_TOKEN`; there is no token CLI flag. Do not put the token
-in memory, a source ref, a log, a retained command, or a committed file. The
-store keeps only its hash, and policy status/audit never reveal it.
+in memory, a source ref, a log, a retained command, or a committed file. Do not
+paste it into an `export` command; use a history-safe, no-echo prompt supported
+by the current shell or approved secret-manager injection. The store keeps only
+its hash, and policy status/audit never reveal it.
 Inject the variable only into coordinator processes. Ensure every ordinary
 worker is launched with `TREE_RING_COORDINATOR_TOKEN` unset so authority is not
 inherited through fan-out.
@@ -221,7 +224,8 @@ replace it immediately with the newly printed capability:
 
 ```bash
 tree-ring --root .tree-ring policy rotate --coordinator release-coordinator-next
-export TREE_RING_COORDINATOR_TOKEN='<new one-time capability>'
+# Replace TREE_RING_COORDINATOR_TOKEN through the same history-safe, no-echo
+# input path before using the new capability.
 tree-ring --root .tree-ring policy disable
 unset TREE_RING_COORDINATOR_TOKEN
 ```

--- a/docs/protocol/memory-event.md
+++ b/docs/protocol/memory-event.md
@@ -47,7 +47,8 @@ agent and trusted-process behavior. A coordinator can explicitly enable
 
 ```bash
 tree-ring policy enable --coordinator <label>
-export TREE_RING_COORDINATOR_TOKEN='<one-time capability printed by enable>'
+# Set and export TREE_RING_COORDINATOR_TOKEN with a history-safe, no-echo prompt
+# supported by your shell, or inject it through an approved secret manager.
 tree-ring policy status
 tree-ring policy audit --limit 100
 ```
@@ -55,8 +56,10 @@ tree-ring policy audit --limit 100
 The capability is accepted only through `TREE_RING_COORDINATOR_TOKEN`; it is
 never a CLI flag or event field. The store persists only a hash. Enable and
 rotate return the plaintext capability once, while status and audit never
-return it. Coordinators must keep the variable out of ordinary worker
-environments; a fan-out child that inherits the valid token inherits
+return it. Do not paste the capability into an `export` command; use a
+history-safe, no-echo prompt supported by the current shell or approved
+secret-manager injection. Coordinators must keep the variable out of ordinary
+worker environments; a fan-out child that inherits the valid token inherits
 coordinator write authority.
 
 Official Rust writers open the store with a `WriteContext` containing an
@@ -80,7 +83,8 @@ Rotate and disable require the current capability:
 
 ```bash
 tree-ring policy rotate --coordinator <label>
-export TREE_RING_COORDINATOR_TOKEN='<new one-time capability>'
+# Replace TREE_RING_COORDINATOR_TOKEN through the same history-safe, no-echo
+# input path before using the new capability.
 tree-ring policy disable
 unset TREE_RING_COORDINATOR_TOKEN
 ```

--- a/plugins/tree-ring-memory/PRIVACY.md
+++ b/plugins/tree-ring-memory/PRIVACY.md
@@ -20,5 +20,6 @@ AI host, operating system, source-control provider, or any other tool the user
 chooses to invoke.
 
 Support and privacy questions may be filed at
-<https://github.com/TerminallyLazy/tree-ring-memory-codex-plugin/issues>.
-Do not include secrets or private memory content in a public issue.
+<https://github.com/TerminallyLazy/Tree-Ring-Memory/issues>.
+Do not include secrets, vulnerability details, or private memory content in a
+public issue.

--- a/plugins/tree-ring-memory/SECURITY.md
+++ b/plugins/tree-ring-memory/SECURITY.md
@@ -2,7 +2,7 @@
 
 ## Supported Versions
 
-The `main` branch is the supported version of this Codex plugin wrapper.
+The `main` branch is the supported version of this agent plugin package.
 
 The Tree Ring Memory framework and CLI are maintained in the canonical
 repository:
@@ -11,13 +11,17 @@ repository:
 
 ## Reporting A Vulnerability
 
-Open a private security advisory on GitHub when available, or open a public
-issue with sensitive details removed:
+Report vulnerabilities privately through the canonical repository's GitHub
+security advisory form:
 
-<https://github.com/TerminallyLazy/tree-ring-memory-codex-plugin/issues>
+<https://github.com/TerminallyLazy/Tree-Ring-Memory/security/advisories/new>
 
-Do not include secrets, tokens, private memory contents, or personal data in a
-public issue.
+Use the canonical issue tracker only for non-sensitive support:
+
+<https://github.com/TerminallyLazy/Tree-Ring-Memory/issues>
+
+Never include vulnerability details, secrets, tokens, private memory contents,
+or personal data in a public issue.
 
 ## Data Handling
 

--- a/plugins/tree-ring-memory/TERMS.md
+++ b/plugins/tree-ring-memory/TERMS.md
@@ -17,4 +17,4 @@ availability, accuracy, non-infringement, or data durability, to the maximum
 extent permitted by law. The limitations in the included MIT License apply.
 
 Questions may be filed at
-<https://github.com/TerminallyLazy/tree-ring-memory-codex-plugin/issues>.
+<https://github.com/TerminallyLazy/Tree-Ring-Memory/issues>.

--- a/plugins/tree-ring-memory/skills/tree-ring-memory/SKILL.md
+++ b/plugins/tree-ring-memory/skills/tree-ring-memory/SKILL.md
@@ -392,7 +392,8 @@ optional Coordinated policy:
 
 ```bash
 tree-ring --root .tree-ring policy enable --coordinator release-coordinator
-export TREE_RING_COORDINATOR_TOKEN='<one-time capability printed by enable>'
+# Set and export TREE_RING_COORDINATOR_TOKEN with a history-safe, no-echo prompt
+# supported by your shell, or inject it through an approved secret manager.
 tree-ring --root .tree-ring policy status
 tree-ring --root .tree-ring policy audit --limit 100
 ```
@@ -401,7 +402,9 @@ Enable prints the capability once. Put it only in
 `TREE_RING_COORDINATOR_TOKEN`; never pass it as a CLI flag or place it in a
 memory, log, source ref, transcript, or committed file. Tree Ring stores only a
 hash. `policy status` and `policy audit` are read-only and do not reveal the
-capability. Inject it only into coordinator processes, and launch every ordinary
+capability. Do not paste it into an `export` command; use a history-safe,
+no-echo prompt supported by the current shell or approved secret-manager
+injection. Inject it only into coordinator processes, and launch every ordinary
 worker with `TREE_RING_COORDINATOR_TOKEN` unset so fan-out does not inherit
 coordinator authority.
 
@@ -428,7 +431,8 @@ replace the environment value with the newly printed capability:
 
 ```bash
 tree-ring --root .tree-ring policy rotate --coordinator release-coordinator-next
-export TREE_RING_COORDINATOR_TOKEN='<new one-time capability>'
+# Replace TREE_RING_COORDINATOR_TOKEN through the same history-safe, no-echo
+# input path before using the new capability.
 tree-ring --root .tree-ring policy disable
 unset TREE_RING_COORDINATOR_TOKEN
 ```

--- a/scripts/validate-plugin-packages.py
+++ b/scripts/validate-plugin-packages.py
@@ -10,6 +10,9 @@ from typing import Any
 
 ROOT = Path(__file__).resolve().parents[1]
 PLUGIN = ROOT / "plugins" / "tree-ring-memory"
+UNSAFE_TOKEN_EXPORT = "export TREE_RING_COORDINATOR_TOKEN='<"
+CANONICAL_ISSUES = "https://github.com/TerminallyLazy/Tree-Ring-Memory/issues"
+CANONICAL_ADVISORY = "https://github.com/TerminallyLazy/Tree-Ring-Memory/security/advisories/new"
 
 
 def load_json(path: Path) -> dict[str, Any]:
@@ -114,6 +117,7 @@ def validate_shared_contract() -> None:
             "scripts/certify-tree-ring.sh",
             "does not run certification",
             "TREE_RING_COORDINATOR_TOKEN",
+            "history-safe, no-echo",
             "configured-awaiting-proof",
             "needs-plugin",
             "same-host local-filesystem processes",
@@ -132,10 +136,30 @@ def validate_shared_contract() -> None:
     require(not (PLUGIN / "scripts" / "certify-tree-ring.sh").exists(), "source certification suite must not be bundled")
     for filename in ("LICENSE", "PRIVACY.md", "SECURITY.md", "TERMS.md", "README.md"):
         require((PLUGIN / filename).is_file(), f"plugin {filename} is missing")
+    require_markers(PLUGIN / "SECURITY.md", [CANONICAL_ADVISORY, CANONICAL_ISSUES])
+    require_markers(PLUGIN / "PRIVACY.md", [CANONICAL_ISSUES])
+    require_markers(PLUGIN / "TERMS.md", [CANONICAL_ISSUES])
+    guidance_paths = [
+        ROOT / "README.md",
+        ROOT / "skills" / "tree-ring-memory" / "SKILL.md",
+        ROOT / "templates" / "dox" / "AGENTS.md",
+        ROOT / "docs" / "integrations" / "agent-skill.md",
+        ROOT / "docs" / "protocol" / "memory-event.md",
+        ROOT / "crates" / "tree-ring-memory-cli" / "src" / "agent_awareness.rs",
+        skill,
+    ]
+    for path in guidance_paths:
+        text = path.read_text(encoding="utf-8")
+        require(UNSAFE_TOKEN_EXPORT not in text, f"unsafe token export remains in {path.relative_to(ROOT)}")
+        require("history-safe, no-echo" in text, f"safe token guidance is missing from {path.relative_to(ROOT)}")
     for path in PLUGIN.rglob("*"):
         if path.is_file() and path.suffix in {".md", ".json"}:
             text = path.read_text(encoding="utf-8")
             require("[TODO:" not in text and "Local developer" not in text, f"placeholder remains in {path.relative_to(ROOT)}")
+            require(
+                "tree-ring-memory-codex-plugin/issues" not in text,
+                f"stale support URL remains in {path.relative_to(ROOT)}",
+            )
 
 
 def main() -> None:

--- a/skills/tree-ring-memory/SKILL.md
+++ b/skills/tree-ring-memory/SKILL.md
@@ -306,7 +306,8 @@ optional Coordinated policy:
 
 ```bash
 tree-ring --root .tree-ring policy enable --coordinator release-coordinator
-export TREE_RING_COORDINATOR_TOKEN='<one-time capability printed by enable>'
+# Set and export TREE_RING_COORDINATOR_TOKEN with a history-safe, no-echo prompt
+# supported by your shell, or inject it through an approved secret manager.
 tree-ring --root .tree-ring policy status
 tree-ring --root .tree-ring policy audit --limit 100
 ```
@@ -315,7 +316,9 @@ Enable prints the capability once. Put it only in
 `TREE_RING_COORDINATOR_TOKEN`; never pass it as a CLI flag or place it in a
 memory, log, source ref, transcript, or committed file. Tree Ring stores only a
 hash. `policy status` and `policy audit` are read-only and do not reveal the
-capability. Inject it only into coordinator processes, and launch every ordinary
+capability. Do not paste it into an `export` command; use a history-safe,
+no-echo prompt supported by the current shell or approved secret-manager
+injection. Inject it only into coordinator processes, and launch every ordinary
 worker with `TREE_RING_COORDINATOR_TOKEN` unset so fan-out does not inherit
 coordinator authority.
 
@@ -342,7 +345,8 @@ replace the environment value with the newly printed capability:
 
 ```bash
 tree-ring --root .tree-ring policy rotate --coordinator release-coordinator-next
-export TREE_RING_COORDINATOR_TOKEN='<new one-time capability>'
+# Replace TREE_RING_COORDINATOR_TOKEN through the same history-safe, no-echo
+# input path before using the new capability.
 tree-ring --root .tree-ring policy disable
 unset TREE_RING_COORDINATOR_TOKEN
 ```

--- a/templates/dox/AGENTS.md
+++ b/templates/dox/AGENTS.md
@@ -112,14 +112,17 @@ Coordinated policy:
 
 ```bash
 tree-ring --root .tree-ring policy enable --coordinator release-coordinator
-export TREE_RING_COORDINATOR_TOKEN='<one-time capability printed by enable>'
+# Set and export TREE_RING_COORDINATOR_TOKEN with a history-safe, no-echo prompt
+# supported by your shell, or inject it through an approved secret manager.
 tree-ring --root .tree-ring policy status
 tree-ring --root .tree-ring policy audit --limit 100
 ```
 
 Never pass the capability as a CLI flag or store it in memory, logs, source
-refs, or committed files. Tree Ring prints it once and stores only its hash.
-Inject it only into coordinator processes; launch ordinary workers with
+refs, or committed files. Tree Ring prints it once and stores only its hash. Do
+not paste it into an `export` command; use a history-safe, no-echo prompt
+supported by the current shell or approved secret-manager injection. Inject it
+only into coordinator processes; launch ordinary workers with
 `TREE_RING_COORDINATOR_TOKEN` unset.
 
 In Coordinated mode, an ordinary worker may create only non-heartwood
@@ -139,7 +142,8 @@ Rotate and disable only while the current capability is exported:
 
 ```bash
 tree-ring --root .tree-ring policy rotate --coordinator release-coordinator-next
-export TREE_RING_COORDINATOR_TOKEN='<new one-time capability>'
+# Replace TREE_RING_COORDINATOR_TOKEN through the same history-safe, no-echo
+# input path before using the new capability.
 tree-ring --root .tree-ring policy disable
 unset TREE_RING_COORDINATOR_TOKEN
 ```


### PR DESCRIPTION
## Summary
- point security, privacy, and support guidance at the canonical repository
- use the now-enabled private vulnerability reporting endpoint for sensitive reports
- remove token-bearing `export` examples from plugin, core, DOX, protocol, and generated agent guidance
- require history-safe, no-echo or secret-manager injection and validate against regressions

## Validation
- `python3 scripts/validate-plugin-packages.py`
- `python3 /Users/lazy/.codex/skills/.system/plugin-creator/scripts/validate_plugin.py plugins/tree-ring-memory`
- `claude plugin validate .`
- `claude plugin validate plugins/tree-ring-memory`
- `cargo fmt --all -- --check`
- `cargo test -p tree-ring-memory-cli agent_awareness --locked` (14 passed)
- `git diff --check`

Addresses the actionable CodeRabbit review comments on #47.

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR addresses security review findings by removing unsafe token-bearing `export` examples from all documentation and replacing them with guidance to use history-safe, no-echo prompts or secret-manager injection for the `TREE_RING_COORDINATOR_TOKEN`. It also updates security, privacy, and support links to point to the canonical repository, enables private vulnerability reporting, and adds validation checks to prevent regressions of these security practices.

⏱️ Estimated Review Time: 30-90 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `scripts/validate-plugin-packages.py` |
| 2 | `plugins/tree-ring-memory/SECURITY.md` |
| 3 | `plugins/tree-ring-memory/PRIVACY.md` |
| 4 | `plugins/tree-ring-memory/TERMS.md` |
| 5 | `README.md` |
| 6 | `skills/tree-ring-memory/SKILL.md` |
| 7 | `plugins/tree-ring-memory/skills/tree-ring-memory/SKILL.md` |
| 8 | `docs/integrations/agent-skill.md` |
| 9 | `templates/dox/AGENTS.md` |
| 10 | `docs/protocol/memory-event.md` |
| 11 | `crates/tree-ring-memory-cli/src/agent_awareness.rs` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->