### PR TITLE
chore: sync plugin patch releases

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,7 +5,7 @@
     "url": "https://github.com/TerminallyLazy"
   },
   "description": "Claude Code marketplace for Tree Ring Memory v0.14 local-first recall and receipt-backed harness readiness.",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "plugins": [
     {
       "name": "tree-ring-memory",

--- a/plugins/tree-ring-memory/.claude-plugin/plugin.json
+++ b/plugins/tree-ring-memory/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "tree-ring-memory",
   "displayName": "Tree Ring Memory",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Local-first memory lifecycle and receipt-backed harness guidance for Claude Code using Tree Ring Memory v0.14+.",
   "author": {
     "name": "TerminallyLazy",

--- a/plugins/tree-ring-memory/.codex-plugin/plugin.json
+++ b/plugins/tree-ring-memory/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "tree-ring-memory",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Local-first memory lifecycle and receipt-backed harness guidance for coding agents using Tree Ring Memory v0.14+.",
   "author": {
     "name": "TerminallyLazy",

--- a/plugins/tree-ring-memory/README.md
+++ b/plugins/tree-ring-memory/README.md
@@ -4,8 +4,8 @@ This directory is the repository-distributed Tree Ring Memory plugin for
 ChatGPT/Codex and Claude Code. It packages instruction files only; the local
 Tree Ring Memory CLI remains the runtime and data owner.
 
-The Codex manifest is version `0.3.1`. The Claude Code manifest is version
-`0.3.0`. Both target Tree Ring Memory CLI `0.14.0` or newer and share the same
+The Codex manifest is version `0.3.2`. The Claude Code manifest is version
+`0.3.1`. Both target Tree Ring Memory CLI `0.14.0` or newer and share the same
 reviewed wrapper skill.
 
 The package does not run a background service, scrape chats, install hooks, or

--- a/scripts/validate-plugin-packages.py
+++ b/scripts/validate-plugin-packages.py
@@ -60,7 +60,7 @@ def validate_codex() -> None:
 
     manifest = load_json(PLUGIN / ".codex-plugin" / "plugin.json")
     require(manifest.get("name") == "tree-ring-memory", "Codex manifest name is stale")
-    require(manifest.get("version") == "0.3.1", "Codex manifest version is stale")
+    require(manifest.get("version") == "0.3.2", "Codex manifest version is stale")
     require(manifest.get("skills") == "./skills/", "Codex skills path is stale")
     for unsupported in ("mcpServers", "apps", "hooks"):
         require(unsupported not in manifest, f"skills-only Codex plugin must not declare {unsupported}")
@@ -76,7 +76,7 @@ def validate_codex() -> None:
 def validate_claude() -> None:
     marketplace = load_json(ROOT / ".claude-plugin" / "marketplace.json")
     require(marketplace.get("name") == "tree-ring-memory", "Claude marketplace name is stale")
-    require(marketplace.get("version") == "0.3.0", "Claude marketplace version is stale")
+    require(marketplace.get("version") == "0.3.1", "Claude marketplace version is stale")
     require(isinstance(marketplace.get("owner"), dict), "Claude marketplace owner is required")
     entries = marketplace.get("plugins")
     require(isinstance(entries, list) and len(entries) == 1, "Claude marketplace must contain one plugin")


### PR DESCRIPTION
## Summary
- advertise the published Codex v0.3.2 wrapper in the repository marketplace package
- synchronize the Claude plugin and marketplace at published v0.3.1
- keep package validation and documentation aligned with the public releases

## Validation
- `python3 scripts/validate-plugin-packages.py`
- Codex plugin package validator
- `claude plugin validate .`
- `claude plugin validate plugins/tree-ring-memory`
- JSON validation
- `git diff --check`

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR synchronizes version numbers across plugin manifests and documentation to align with published releases. The Codex plugin wrapper is updated to `0.3.2`, the Claude plugin and marketplace are updated to `0.3.1`, and the validation script is updated to enforce these new version constraints. All changes are version number updates in configuration files and documentation.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `plugins/tree-ring-memory/README.md` |
| 2 | `plugins/tree-ring-memory/.codex-plugin/plugin.json` |
| 3 | `plugins/tree-ring-memory/.claude-plugin/plugin.json` |
| 4 | `.claude-plugin/marketplace.json` |
| 5 | `scripts/validate-plugin-packages.py` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->