### PR TITLE
Update release artifact download action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -120,7 +120,7 @@ jobs:
       contents: write
     steps:
       - name: Download release assets
-        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: tree-ring-memory-*
           merge-multiple: true


### PR DESCRIPTION
## Summary
- update the pinned official `actions/download-artifact` action from v5 to v8.0.1
- resolve the Node.js 20 deprecation annotation emitted by the v0.15.0 release workflow

## Validation
- verified v8.0.1 tag and exact commit through the official actions/download-artifact repository
- parsed the updated workflow YAML

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR updates the `actions/download-artifact` GitHub Action from v5 to v8.0.1 in the release workflow to resolve Node.js 20 deprecation warnings. The change updates both the commit hash and version tag to point to the newer action version while maintaining the same functionality.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `.github/workflows/release.yml` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->