### PR TITLE
Fix Agent Zero 3.3 activation compatibility

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1690,7 +1690,7 @@ checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "tree-ring-memory-cli"
-version = "0.15.3"
+version = "0.15.4"
 dependencies = [
  "chrono",
  "clap",
@@ -1709,7 +1709,7 @@ dependencies = [
 
 [[package]]
 name = "tree-ring-memory-core"
-version = "0.15.3"
+version = "0.15.4"
 dependencies = [
  "chrono",
  "libc",
@@ -1725,7 +1725,7 @@ dependencies = [
 
 [[package]]
 name = "tree-ring-memory-sqlite"
-version = "0.15.3"
+version = "0.15.4"
 dependencies = [
  "rusqlite",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.15.3"
+version = "0.15.4"
 edition = "2021"
 license = "MIT"
 authors = ["TerminallyLazy"]

--- a/crates/tree-ring-memory-cli/Cargo.toml
+++ b/crates/tree-ring-memory-cli/Cargo.toml
@@ -26,8 +26,8 @@ semver.workspace = true
 sha2.workspace = true
 tempfile.workspace = true
 uuid.workspace = true
-tree-ring-memory-core = { path = "../tree-ring-memory-core", version = "0.15.3" }
-tree-ring-memory-sqlite = { path = "../tree-ring-memory-sqlite", version = "0.15.3" }
+tree-ring-memory-core = { path = "../tree-ring-memory-core", version = "0.15.4" }
+tree-ring-memory-sqlite = { path = "../tree-ring-memory-sqlite", version = "0.15.4" }
 
 [dev-dependencies]
 rusqlite.workspace = true

--- a/crates/tree-ring-memory-cli/src/activation/adapters.rs
+++ b/crates/tree-ring-memory-cli/src/activation/adapters.rs
@@ -15,8 +15,12 @@ pub const AGENT_ZERO_PLUGIN_MANIFEST_ENV: &str = "TREE_RING_AGENT_ZERO_PLUGIN_MA
 
 const AGENT_ZERO_CAPABILITY_FILE: &str = "activation-capability.json";
 const AGENT_ZERO_CAPABILITY_KIND: &str = "tree-ring-agent-zero-plugin-capability";
-const AGENT_ZERO_CAPABILITY_CONTRACTS: &[(&str, &str, &str)] =
-    &[("3.1.0", "0.14.0", "0.14"), ("3.2.0", "0.15.3", "0.15")];
+const AGENT_ZERO_CAPABILITY_CONTRACTS: &[(&str, &str, &str)] = &[
+    ("3.1.0", "0.14.0", "0.14"),
+    ("3.2.0", "0.15.3", "0.15"),
+    ("3.3.0", "0.15.3", "0.15"),
+    ("3.3.1", "0.15.3", "0.15"),
+];
 const MAX_AGENT_ZERO_CAPABILITY_BYTES: u64 = 16 * 1024;
 
 /// Project paths used by activation. Adapter plans always target this root.
@@ -1108,6 +1112,24 @@ mod tests {
         fs::create_dir_all(&plugin).unwrap();
 
         let descriptor = write_capability_descriptor(&plugin, true);
+        assert_eq!(
+            read_agent_zero_plugin_manifest(&project, &descriptor),
+            Some(AgentZeroPluginManifest::compatible())
+        );
+
+        fs::write(
+            plugin.join("plugin.yaml"),
+            "name: tree_ring_memory\nversion: 3.3.1\n",
+        )
+        .unwrap();
+        fs::write(
+            &descriptor,
+            capability_document(true).replace(
+                "\"plugin_version\":\"3.2.0\"",
+                "\"plugin_version\":\"3.3.1\"",
+            ),
+        )
+        .unwrap();
         assert_eq!(
             read_agent_zero_plugin_manifest(&project, &descriptor),
             Some(AgentZeroPluginManifest::compatible())

--- a/crates/tree-ring-memory-cli/tests/harness_activation_acceptance.rs
+++ b/crates/tree-ring-memory-cli/tests/harness_activation_acceptance.rs
@@ -918,13 +918,13 @@ fn install_agent_zero_plugin(base: &Path) -> PathBuf {
     fs::create_dir_all(&plugin).unwrap();
     fs::write(
         plugin.join("plugin.yaml"),
-        "name: tree_ring_memory\nversion: 3.2.0\n",
+        "name: tree_ring_memory\nversion: 3.3.1\n",
     )
     .unwrap();
     let descriptor = plugin.join("activation-capability.json");
     fs::write(
         &descriptor,
-        r#"{"schema_version":1,"kind":"tree-ring-agent-zero-plugin-capability","plugin_id":"tree_ring_memory","plugin_version":"3.2.0","activation_protocol_version":1,"tree_ring_version":{"min":"0.15.3","minor":"0.15"},"enabled":true}"#,
+        r#"{"schema_version":1,"kind":"tree-ring-agent-zero-plugin-capability","plugin_id":"tree_ring_memory","plugin_version":"3.3.1","activation_protocol_version":1,"tree_ring_version":{"min":"0.15.3","minor":"0.15"},"enabled":true}"#,
     )
     .unwrap();
     descriptor


### PR DESCRIPTION
## Summary
- trust the published Agent Zero Tree Ring Memory 3.3.0 and 3.3.1 activation descriptors
- bump the CLI patch release to 0.15.4
- exercise 3.3.1 in the real harness activation acceptance test while retaining 3.2 compatibility

## Verification
- cargo fmt --check
- cargo test -p tree-ring-memory-cli --locked
- cargo build --release -p tree-ring-memory-cli --locked

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR adds compatibility support for Agent Zero plugin versions 3.3.0 and 3.3.1 by updating the activation capability contracts table, while also bumping the CLI patch version from 0.15.3 to 0.15.4. The changes include updating version numbers across the workspace, adding new capability contract entries for the 3.3.x versions, and updating the acceptance test harness to exercise version 3.3.1 instead of 3.2.0 while maintaining backward compatibility with 3.2.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `Cargo.toml` |
| 2 | `Cargo.lock` |
| 3 | `crates/tree-ring-memory-cli/Cargo.toml` |
| 4 | `crates/tree-ring-memory-cli/src/activation/adapters.rs` |
| 5 | `crates/tree-ring-memory-cli/tests/harness_activation_acceptance.rs` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added compatibility support for Agent Zero plugin versions 3.3.0 and 3.3.1.
  - Updated plugin validation to accept version 3.3.1 integrations.

- **Improvements**
  - Updated the bundled Agent Zero compatibility checks and validation scenarios to reflect the latest supported plugin version.

- **Release**
  - Incremented the application version to 0.15.4.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->