### PR TITLE
Add bounded automatic lifecycle memory capture

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,14 +4,14 @@
     "name": "TerminallyLazy",
     "url": "https://github.com/TerminallyLazy"
   },
-  "description": "Claude Code marketplace for Tree Ring Memory v0.15 verified bootstrap, local-first recall, and receipt-backed harness readiness.",
-  "version": "0.3.2",
+  "description": "Claude Code marketplace for Tree Ring Memory v0.15 verified bootstrap, lifecycle recall, strict automatic capture, and receipt-backed harness readiness.",
+  "version": "0.3.3",
   "plugins": [
     {
       "name": "tree-ring-memory",
       "source": "./plugins/tree-ring-memory",
       "displayName": "Tree Ring Memory",
-      "description": "Local-first memory lifecycle, project bootstrap, and receipt-backed harness guidance for Claude Code using Tree Ring Memory v0.15+.",
+      "description": "Local-first recall, strict agent-mediated automatic capture, project bootstrap, and receipt-backed harness guidance for Claude Code using Tree Ring Memory v0.15+.",
       "author": {
         "name": "TerminallyLazy",
         "url": "https://github.com/TerminallyLazy"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1690,7 +1690,7 @@ checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "tree-ring-memory-cli"
-version = "0.15.4"
+version = "0.15.5"
 dependencies = [
  "chrono",
  "clap",
@@ -1709,7 +1709,7 @@ dependencies = [
 
 [[package]]
 name = "tree-ring-memory-core"
-version = "0.15.4"
+version = "0.15.5"
 dependencies = [
  "chrono",
  "libc",
@@ -1725,7 +1725,7 @@ dependencies = [
 
 [[package]]
 name = "tree-ring-memory-sqlite"
-version = "0.15.4"
+version = "0.15.5"
 dependencies = [
  "rusqlite",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.15.4"
+version = "0.15.5"
 edition = "2021"
 license = "MIT"
 authors = ["TerminallyLazy"]

--- a/README.md
+++ b/README.md
@@ -244,8 +244,9 @@ files in the memory root:
 - `.tree-ring/AGENTS.md`: DOX-style Tree Ring Memory guidance and root
   `AGENTS.md` merge notes.
 - `.tree-ring/SKILL.md`: portable skill instructions for agent runtimes.
-- `.tree-ring/CLI.md`: quick command reference for recall, remember, evidence,
-  DOX/Revolve sync, import/export, audit, maintenance, and TUI usage.
+- `.tree-ring/CLI.md`: quick command reference for recall, strict automatic
+  capture, remember, evidence, DOX/Revolve sync, import/export, audit,
+  maintenance, and TUI usage.
 
 Existing awareness files are left untouched. Tree Ring Memory does not modify a
 project's root `AGENTS.md`; merge the generated guidance manually when you want
@@ -337,6 +338,7 @@ The `tree-ring` command is the Rust CLI.
 ```bash
 tree-ring init
 tree-ring remember "Use protocol-first design." --event-type decision --tag architecture
+tree-ring capture "Use receipt-backed lifecycle checkpoints." --event-type decision --ring cambium --project example-service --agent-profile codex --workflow-id workflow-1 --session-id session-1 --operation-id auto-checkpoint-1 --source-ref agent-checkpoint:checkpoint
 tree-ring evidence "Snapshot invalidation fixed stale unread chat state." --outcome promoted --evidence-ref evals/chat-state/run-042 --score 0.91
 tree-ring recall "protocol design"
 tree-ring forget mem_example --mode delete --reason "example cleanup"
@@ -361,6 +363,9 @@ Command ownership is Rust-native:
   `.tree-ring/SKILL.md`, and `.tree-ring/CLI.md` without overwriting existing
   files, then attempts create-only project harness configuration.
 - `remember`, `recall`, and `forget` cover direct memory capture, retrieval, redaction, and deletion.
+- `capture` is the strict automatic lifecycle-write path: agent-scoped only,
+  normal sensitivity only, bounded cambium/scar/seed classifications, and
+  required checkpoint identity, idempotency, and provenance.
 - `evidence` is the Revolve-inspired improvement-loop entry point for evaluated outcomes.
 - `dox sync` and `revolve sync` are read-only source adapters that summarize and point back to authoritative files.
 - `integrations scan` discovers nearby agent-framework markers and suggests setup paths without changing their config.
@@ -784,7 +789,7 @@ The current activation protocol is documented in
 
 ## Agent Workflow Integration
 
-- `skills/tree-ring-memory/SKILL.md` gives agents portable guidance for when to recall, remember, redact, forget, or avoid memory capture.
+- `skills/tree-ring-memory/SKILL.md` gives agents portable guidance for when to recall, automatically capture, remember, redact, forget, or avoid memory capture.
 - `templates/dox/AGENTS.md` is a DOX-style project contract template for repos that want Tree Ring Memory rules alongside source code.
 - `docs/integrations/agent-skill.md` explains how to use both without making memory more authoritative than local project docs.
 - `tree-ring init` creates canonical guidance and safely configures maintained
@@ -814,11 +819,13 @@ view to `configured-awaiting-proof` and then receipt-backed `active`. There is
 no manual descriptor workflow, and the core/plugin release pair must be
 compatible before this path is available.
 
-Memory updates are agent-mediated. Bridge files tell the active agent when to
-call `tree-ring recall`, `tree-ring remember`, `tree-ring evidence`,
-`tree-ring forget`, `tree-ring consolidate --dry-run`, or `tree-ring maintain`.
-Tree Ring does not scrape transcripts, run a hidden recorder, or turn TUI
-event-stream pulses into durable memory without an explicit write command.
+Memory updates are agent-mediated. Maintained lifecycle bridges perform recall
+at session and subagent start, then enforce one automatic checkpoint at stop.
+The active agent submits zero to three concise durable normal-sensitivity
+candidates through strict `tree-ring capture`; manual `remember` and `evidence`
+remain separate surfaces. Zero is correct when nothing reusable occurred.
+Tree Ring does not scrape transcripts, run a hidden recorder, or turn TUI event
+streams into durable memory without a validated write command.
 
 ## Brand Assets
 

--- a/crates/tree-ring-memory-cli/Cargo.toml
+++ b/crates/tree-ring-memory-cli/Cargo.toml
@@ -26,8 +26,8 @@ semver.workspace = true
 sha2.workspace = true
 tempfile.workspace = true
 uuid.workspace = true
-tree-ring-memory-core = { path = "../tree-ring-memory-core", version = "0.15.4" }
-tree-ring-memory-sqlite = { path = "../tree-ring-memory-sqlite", version = "0.15.4" }
+tree-ring-memory-core = { path = "../tree-ring-memory-core", version = "0.15.5" }
+tree-ring-memory-sqlite = { path = "../tree-ring-memory-sqlite", version = "0.15.5" }
 
 [dev-dependencies]
 rusqlite.workspace = true

--- a/crates/tree-ring-memory-cli/src/actions/remember.rs
+++ b/crates/tree-ring-memory-cli/src/actions/remember.rs
@@ -24,6 +24,20 @@ pub struct RememberReport {
     pub created: bool,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CaptureRequest {
+    pub summary: String,
+    pub event_type: String,
+    pub ring: String,
+    pub project: String,
+    pub agent_profile: String,
+    pub workflow_id: String,
+    pub session_id: String,
+    pub operation_id: String,
+    pub source_ref: String,
+    pub tags: Vec<String>,
+}
+
 pub fn remember(
     store: &mut SQLiteMemoryStore,
     request: RememberRequest,
@@ -69,6 +83,96 @@ pub fn remember(
     event.validate().map_err(|err| err.to_string())?;
     let (memory, created) = store_event_idempotently(store, &event)?;
     Ok(RememberReport { memory, created })
+}
+
+/// Stores one strict agent-mediated automatic capture candidate.
+///
+/// Automatic capture deliberately cannot create shared, heartwood, evaluation,
+/// or sensitive memory. The lifecycle hook supplies the trusted routing and
+/// checkpoint provenance; the active agent supplies only the concise durable
+/// candidate and its bounded classification.
+pub fn capture(
+    store: &mut SQLiteMemoryStore,
+    mut request: CaptureRequest,
+) -> ActionResult<RememberReport> {
+    let allowed = matches!(
+        (request.event_type.as_str(), request.ring.as_str()),
+        ("preference" | "decision", "cambium")
+            | ("lesson" | "correction", "cambium" | "scar")
+            | ("warning", "scar")
+            | ("seed", "seed")
+    );
+    if !allowed {
+        if !matches!(request.ring.as_str(), "cambium" | "scar" | "seed") {
+            return Err("automatic capture uses an unsupported ring".to_string());
+        }
+        return Err("automatic capture uses an unsupported event type or ring pairing".to_string());
+    }
+    let checkpoint_id = request
+        .source_ref
+        .strip_prefix("agent-checkpoint:")
+        .filter(|value| {
+            !value.is_empty()
+                && value.len() <= 128
+                && value
+                    .chars()
+                    .all(|character| character.is_ascii_alphanumeric() || "-_.".contains(character))
+        })
+        .ok_or_else(|| {
+            "automatic capture source-ref must contain a safe agent-checkpoint id".to_string()
+        })?;
+    let operation_prefix = format!("auto-{checkpoint_id}-");
+    let slot = request
+        .operation_id
+        .strip_prefix(&operation_prefix)
+        .filter(|slot| matches!(*slot, "1" | "2" | "3"));
+    if slot.is_none() {
+        return Err(
+            "automatic capture operation-id must match its checkpoint and slot 1, 2, or 3"
+                .to_string(),
+        );
+    }
+
+    let guard = SensitivityGuard::default();
+    let values = [
+        request.summary.as_str(),
+        request.event_type.as_str(),
+        request.ring.as_str(),
+        request.project.as_str(),
+        request.agent_profile.as_str(),
+        request.workflow_id.as_str(),
+        request.session_id.as_str(),
+        request.operation_id.as_str(),
+        request.source_ref.as_str(),
+    ]
+    .into_iter()
+    .chain(request.tags.iter().map(String::as_str));
+    let sensitivity = guard
+        .detect_text_sensitivity(values)
+        .map_err(|_| "automatic capture accepts only normal-sensitivity candidates".to_string())?;
+    if sensitivity != "normal" {
+        return Err("automatic capture accepts only normal-sensitivity candidates".to_string());
+    }
+    if !request.tags.iter().any(|tag| tag == "automatic-capture") {
+        request.tags.push("automatic-capture".to_string());
+    }
+
+    remember(
+        store,
+        RememberRequest {
+            summary: request.summary,
+            event_type: request.event_type,
+            ring: request.ring,
+            scope: "agent".to_string(),
+            project: Some(request.project),
+            agent_profile: Some(request.agent_profile),
+            workflow_id: Some(request.workflow_id),
+            session_id: Some(request.session_id),
+            operation_id: Some(request.operation_id),
+            source_ref: Some(request.source_ref),
+            tags: request.tags,
+        },
+    )
 }
 
 pub fn store_event_idempotently(
@@ -205,6 +309,85 @@ mod tests {
             Some("finding-storage-lock")
         );
         assert_eq!(report.memory.source.ref_, "runs/fanout-42/reviewer-2.json");
+    }
+
+    #[test]
+    fn automatic_capture_stores_only_agent_scoped_checkpoint_memory() {
+        let dir = tempdir().unwrap();
+        let mut store = SQLiteMemoryStore::open(dir.path().join("memory.sqlite")).unwrap();
+
+        let report = capture(
+            &mut store,
+            CaptureRequest {
+                summary: "Use receipt-backed lifecycle hooks for automatic recall.".to_string(),
+                event_type: "decision".to_string(),
+                ring: "cambium".to_string(),
+                project: "tree-ring-memory".to_string(),
+                agent_profile: "codex".to_string(),
+                workflow_id: "workflow-1".to_string(),
+                session_id: "session-1".to_string(),
+                operation_id: "auto-checkpoint-1-1".to_string(),
+                source_ref: "agent-checkpoint:checkpoint-1".to_string(),
+                tags: vec!["hooks".to_string()],
+            },
+        )
+        .unwrap();
+
+        assert!(report.created);
+        assert_eq!(report.memory.scope, "agent");
+        assert_eq!(report.memory.agent_profile.as_deref(), Some("codex"));
+        assert!(report
+            .memory
+            .tags
+            .iter()
+            .any(|tag| tag == "automatic-capture"));
+    }
+
+    #[test]
+    fn automatic_capture_rejects_sensitive_or_unbounded_candidates() {
+        let dir = tempdir().unwrap();
+        let mut store = SQLiteMemoryStore::open(dir.path().join("memory.sqlite")).unwrap();
+        let request = |summary: &str, event_type: &str, ring: &str| CaptureRequest {
+            summary: summary.to_string(),
+            event_type: event_type.to_string(),
+            ring: ring.to_string(),
+            project: "tree-ring-memory".to_string(),
+            agent_profile: "codex".to_string(),
+            workflow_id: "workflow-1".to_string(),
+            session_id: "session-1".to_string(),
+            operation_id: "auto-checkpoint-1-1".to_string(),
+            source_ref: "agent-checkpoint:checkpoint-1".to_string(),
+            tags: Vec::new(),
+        };
+
+        assert!(capture(
+            &mut store,
+            request(
+                "token = sk-proj-abcdefghijklmnopqrstuvwxyz1234567890",
+                "lesson",
+                "cambium"
+            )
+        )
+        .unwrap_err()
+        .contains("normal-sensitivity"));
+        assert!(capture(
+            &mut store,
+            request("Promote this automatically.", "decision", "heartwood")
+        )
+        .unwrap_err()
+        .contains("unsupported ring"));
+        assert!(capture(
+            &mut store,
+            request("Store a transcript summary.", "transcript", "cambium")
+        )
+        .unwrap_err()
+        .contains("unsupported event type"));
+        let mut mismatched = request("Store a fourth candidate.", "lesson", "cambium");
+        mismatched.operation_id = "auto-checkpoint-1-4".to_string();
+        assert!(capture(&mut store, mismatched)
+            .unwrap_err()
+            .contains("slot 1, 2, or 3"));
+        assert!(store.list_all(false).unwrap().is_empty());
     }
 
     #[test]

--- a/crates/tree-ring-memory-cli/src/activation/adapters.rs
+++ b/crates/tree-ring-memory-cli/src/activation/adapters.rs
@@ -20,6 +20,7 @@ const AGENT_ZERO_CAPABILITY_CONTRACTS: &[(&str, &str, &str)] = &[
     ("3.2.0", "0.15.3", "0.15"),
     ("3.3.0", "0.15.3", "0.15"),
     ("3.3.1", "0.15.3", "0.15"),
+    ("3.4.0", "0.15.5", "0.15"),
 ];
 const MAX_AGENT_ZERO_CAPABILITY_BYTES: u64 = 16 * 1024;
 
@@ -392,20 +393,20 @@ enum AdapterSupport {
 const ADAPTERS: [DeclarativeAdapter; 7] = [
     DeclarativeAdapter {
         id: "codex",
-        version: "1",
+        version: "3",
         display_name: "Codex",
         command: "codex",
-        capability: AdapterCapability::GuidanceOnly,
+        capability: AdapterCapability::NativePreflight,
         markers: &[".codex", "AGENTS.md"],
         home_markers: &[".codex"],
         support: AdapterSupport::Maintained,
     },
     DeclarativeAdapter {
         id: "claude-code",
-        version: "1",
+        version: "3",
         display_name: "Claude Code",
         command: "claude",
-        capability: AdapterCapability::WrapperPreflight,
+        capability: AdapterCapability::NativePreflight,
         markers: &[".claude", "CLAUDE.md"],
         home_markers: &[".claude"],
         support: AdapterSupport::Maintained,
@@ -704,6 +705,7 @@ fn adapter_writes(adapter: &DeclarativeAdapter) -> Vec<PlannedWrite> {
     match adapter.id {
         "codex" => vec![
             bridge_write(".agents/skills/tree-ring-memory/SKILL.md"),
+            bridge_write(".codex/hooks.json"),
             managed_block("AGENTS.md", "codex"),
         ],
         "claude-code" => vec![
@@ -952,10 +954,10 @@ mod tests {
                 .collect::<Vec<_>>(),
             vec!["codex", "claude-code", "pi", "agent-zero"]
         );
-        assert!(maintained.iter().all(|adapter| adapter.version() == "1"));
-        assert!(maintained
-            .iter()
-            .all(|adapter| adapter_version(adapter.id()) == Some("1")));
+        assert_eq!(adapter_version("codex"), Some("3"));
+        assert_eq!(adapter_version("claude-code"), Some("3"));
+        assert_eq!(adapter_version("pi"), Some("1"));
+        assert_eq!(adapter_version("agent-zero"), Some("1"));
         for id in ["hermes", "opencode", "goose"] {
             assert_eq!(
                 plan_activation(id, &project()).unwrap().state,
@@ -965,18 +967,14 @@ mod tests {
     }
 
     #[test]
-    fn only_claude_code_advertises_a_tested_wrapper_preflight() {
+    fn maintained_hook_harnesses_advertise_native_preflight() {
         let report = detect_adapters(&project(), &FakeEnvironment::default());
 
-        assert_eq!(
-            report.by_id("claude-code").unwrap().capability,
-            AdapterCapability::WrapperPreflight
-        );
-        for harness_id in ["codex", "pi", "agent-zero"] {
-            assert_ne!(
+        for harness_id in ["codex", "claude-code", "pi", "agent-zero"] {
+            assert_eq!(
                 report.by_id(harness_id).unwrap().capability,
-                AdapterCapability::WrapperPreflight,
-                "{harness_id} must not advertise a generic launch wrapper"
+                AdapterCapability::NativePreflight,
+                "{harness_id} must advertise its tested native lifecycle bridge"
             );
         }
     }
@@ -1112,6 +1110,21 @@ mod tests {
         fs::create_dir_all(&plugin).unwrap();
 
         let descriptor = write_capability_descriptor(&plugin, true);
+        assert_eq!(
+            read_agent_zero_plugin_manifest(&project, &descriptor),
+            Some(AgentZeroPluginManifest::compatible())
+        );
+
+        fs::write(
+            plugin.join("plugin.yaml"),
+            "name: tree_ring_memory\nversion: 3.4.0\n",
+        )
+        .unwrap();
+        fs::write(
+            &descriptor,
+            r#"{"schema_version":1,"kind":"tree-ring-agent-zero-plugin-capability","plugin_id":"tree_ring_memory","plugin_version":"3.4.0","activation_protocol_version":1,"tree_ring_version":{"min":"0.15.5","minor":"0.15"},"enabled":true}"#,
+        )
+        .unwrap();
         assert_eq!(
             read_agent_zero_plugin_manifest(&project, &descriptor),
             Some(AgentZeroPluginManifest::compatible())

--- a/crates/tree-ring-memory-cli/src/activation/bridge.rs
+++ b/crates/tree-ring-memory-cli/src/activation/bridge.rs
@@ -39,8 +39,14 @@ use std::{
 use uuid::Uuid;
 
 const CODEX_RETRY: &str = "tree-ring integrations activate --harness codex --accept-managed-block";
-const CLAUDE_DESCRIPTION: &str = "Tree Ring Memory managed preflight v1";
-const CLAUDE_COMMAND: &str = "tree-ring --root .tree-ring integrations preflight --harness claude-code --input-json-stdin --context-format claude-session-start";
+const CLAUDE_DESCRIPTION: &str = "Tree Ring Memory managed lifecycle v3";
+const CLAUDE_SUBAGENT_DESCRIPTION: &str = "Tree Ring Memory managed subagent lifecycle v3";
+const CLAUDE_STOP_DESCRIPTION: &str = "Tree Ring Memory managed capture checkpoint v3";
+const CLAUDE_SUBAGENT_STOP_DESCRIPTION: &str =
+    "Tree Ring Memory managed subagent capture checkpoint v3";
+const CLAUDE_LEGACY_DESCRIPTION: &str = "Tree Ring Memory managed lifecycle v2";
+const CLAUDE_LEGACY_SUBAGENT_DESCRIPTION: &str = "Tree Ring Memory managed subagent lifecycle v2";
+const CLAUDE_COMMAND: &str = "project_root=\"$(git rev-parse --show-toplevel 2>/dev/null || pwd)\"; tree-ring --root \"$project_root/.tree-ring\" integrations hook --harness claude-code --input-json-stdin";
 
 const SKILL_BRIDGE: &str = r#"---
 name: tree-ring-memory
@@ -54,8 +60,51 @@ Read `.tree-ring/SKILL.md`, `.tree-ring/AGENTS.md`, and `.tree-ring/CLI.md` from
 
 const CODEX_BLOCK_BODY: &str = r#"## Tree Ring Memory
 
-Read `.tree-ring/AGENTS.md`, `.tree-ring/SKILL.md`, and `.tree-ring/CLI.md` before substantive work. Use `tree-ring --root .tree-ring integrations preflight --harness codex` with the later preflight identity interface, and do not claim memory is active without a valid project-local recall receipt.
+Read `.tree-ring/AGENTS.md`, `.tree-ring/SKILL.md`, and `.tree-ring/CLI.md` before substantive work. The project lifecycle hook runs receipt-backed recall at session boundaries and one strict automatic capture checkpoint before a session or subagent turn stops. Do not claim memory is active without a valid project-local recall receipt. Capture zero to three concise durable candidates; never store a transcript or invent memory.
 "#;
+
+fn codex_hooks() -> Value {
+    json!({
+        "description": "Tree Ring Memory managed lifecycle v3",
+        "hooks": {
+            "SessionStart": [{
+                "matcher": "startup|resume|clear|compact",
+                "hooks": [{
+                    "type": "command",
+                    "command": "project_root=\"$(git rev-parse --show-toplevel 2>/dev/null || pwd)\"; tree-ring --root \"$project_root/.tree-ring\" integrations hook --harness codex --input-json-stdin",
+                    "timeout": 10,
+                    "statusMessage": "Loading Tree Ring memory",
+                    "additionalContextLimit": 2500
+                }]
+            }],
+            "SubagentStart": [{
+                "hooks": [{
+                    "type": "command",
+                    "command": "project_root=\"$(git rev-parse --show-toplevel 2>/dev/null || pwd)\"; tree-ring --root \"$project_root/.tree-ring\" integrations hook --harness codex --input-json-stdin",
+                    "timeout": 10,
+                    "statusMessage": "Loading Tree Ring memory",
+                    "additionalContextLimit": 2500
+                }]
+            }],
+            "Stop": [{
+                "hooks": [{
+                    "type": "command",
+                    "command": "project_root=\"$(git rev-parse --show-toplevel 2>/dev/null || pwd)\"; tree-ring --root \"$project_root/.tree-ring\" integrations hook --harness codex --input-json-stdin",
+                    "timeout": 10,
+                    "statusMessage": "Checking durable Tree Ring memory"
+                }]
+            }],
+            "SubagentStop": [{
+                "hooks": [{
+                    "type": "command",
+                    "command": "project_root=\"$(git rev-parse --show-toplevel 2>/dev/null || pwd)\"; tree-ring --root \"$project_root/.tree-ring\" integrations hook --harness codex --input-json-stdin",
+                    "timeout": 10,
+                    "statusMessage": "Checking durable Tree Ring worker memory"
+                }]
+            }]
+        }
+    })
+}
 
 const PI_EXTENSION: &str = r#"import { spawn } from "node:child_process";
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
@@ -1945,8 +1994,9 @@ fn prepare_claude_settings(
 ) -> Result<Option<PreparedFile>, String> {
     let before = project_fs.read_optional(&write.path)?;
     let path = relative_string(&write.path)?;
-    let handler = claude_handler();
-    let handler_hash = sha256(&serde_json::to_vec(&handler).map_err(json_error)?);
+    let handler_hash = sha256(&serde_json::to_vec(&claude_handlers()).map_err(json_error)?);
+    let legacy_handler_hash =
+        sha256(&serde_json::to_vec(&legacy_claude_handlers()).map_err(json_error)?);
     if before.is_none() {
         if owned_files.iter().any(|owned| owned.path == path)
             || managed_blocks
@@ -1956,7 +2006,7 @@ fn prepare_claude_settings(
             return Ok(None);
         }
         let mut root = Map::new();
-        insert_claude_handler(&mut root, handler)?;
+        insert_claude_handlers(&mut root)?;
         let bytes = pretty_json(&Value::Object(root))?;
         upsert_owned_file(owned_files, path, sha256(&bytes));
         return Ok(Some(PreparedFile {
@@ -1978,11 +2028,15 @@ fn prepare_claude_settings(
         match state {
             ClaudeHandlerState::Exact => {}
             ClaudeHandlerState::Absent => {
-                if insert_claude_handler(&mut root, handler).is_err() {
+                if insert_claude_handlers(&mut root).is_err() {
                     return Ok(None);
                 }
             }
-            ClaudeHandlerState::Conflict => return Ok(None),
+            ClaudeHandlerState::Conflict => {
+                if !replace_legacy_claude_handlers(&mut root)? {
+                    return Ok(None);
+                }
+            }
         }
         let desired = pretty_json(&Value::Object(root))?;
         upsert_owned_file(owned_files, path, sha256(&desired));
@@ -2002,11 +2056,20 @@ fn prepare_claude_settings(
         Ok(state) => state,
         Err(_) => return Ok(None),
     };
+    let owns_legacy_bundle = managed_blocks.iter().any(|owned| {
+        owned.path == path
+            && owned.block_id == write.block_id
+            && owned.sha256 == legacy_handler_hash
+    });
     match state {
-        ClaudeHandlerState::Conflict => return Ok(None),
+        ClaudeHandlerState::Conflict => {
+            if !owns_legacy_bundle || !replace_legacy_claude_handlers(&mut root)? {
+                return Ok(None);
+            }
+        }
         ClaudeHandlerState::Exact => {}
         ClaudeHandlerState::Absent => {
-            if insert_claude_handler(&mut root, handler).is_err() {
+            if insert_claude_handlers(&mut root).is_err() {
                 return Ok(None);
             }
         }
@@ -2036,6 +2099,7 @@ fn render_complete_file(
         | ("claude-code", Some(".claude/skills/tree-ring-memory/SKILL.md")) => {
             Ok(SKILL_BRIDGE.as_bytes().to_vec())
         }
+        ("codex", Some(".codex/hooks.json")) => pretty_json(&codex_hooks()),
         ("pi", Some(".pi/extensions/tree-ring-memory.ts")) => Ok(PI_EXTENSION.as_bytes().to_vec()),
         ("agent-zero", Some(".tree-ring/activation/agent-zero.json")) => {
             let binding = json!({
@@ -2075,6 +2139,7 @@ fn validate_plan(plan: &AdapterPlan) -> Result<(), String> {
         match plan.harness_id.as_str() {
             "codex" => vec![
                 ("file", ".agents/skills/tree-ring-memory/SKILL.md", ""),
+                ("file", ".codex/hooks.json", ""),
                 ("block", "AGENTS.md", "codex"),
             ],
             "claude-code" => vec![
@@ -2244,51 +2309,121 @@ fn claude_handler() -> Value {
     json!({
         "type": "command",
         "command": CLAUDE_COMMAND,
-        "description": CLAUDE_DESCRIPTION
+        "description": CLAUDE_DESCRIPTION,
+        "timeout": 10
     })
+}
+
+fn claude_subagent_handler() -> Value {
+    json!({
+        "type": "command",
+        "command": CLAUDE_COMMAND,
+        "description": CLAUDE_SUBAGENT_DESCRIPTION,
+        "timeout": 10
+    })
+}
+
+fn claude_stop_handler() -> Value {
+    json!({
+        "type": "command",
+        "command": CLAUDE_COMMAND,
+        "description": CLAUDE_STOP_DESCRIPTION,
+        "timeout": 10
+    })
+}
+
+fn claude_subagent_stop_handler() -> Value {
+    json!({
+        "type": "command",
+        "command": CLAUDE_COMMAND,
+        "description": CLAUDE_SUBAGENT_STOP_DESCRIPTION,
+        "timeout": 10
+    })
+}
+
+fn legacy_claude_handlers() -> Vec<(&'static str, Value)> {
+    vec![
+        (
+            "SessionStart",
+            json!({
+                "type": "command",
+                "command": CLAUDE_COMMAND,
+                "description": CLAUDE_LEGACY_DESCRIPTION,
+                "timeout": 10
+            }),
+        ),
+        (
+            "SubagentStart",
+            json!({
+                "type": "command",
+                "command": CLAUDE_COMMAND,
+                "description": CLAUDE_LEGACY_SUBAGENT_DESCRIPTION,
+                "timeout": 10
+            }),
+        ),
+    ]
+}
+
+fn claude_handlers() -> Vec<(&'static str, Value)> {
+    vec![
+        ("SessionStart", claude_handler()),
+        ("SubagentStart", claude_subagent_handler()),
+        ("Stop", claude_stop_handler()),
+        ("SubagentStop", claude_subagent_stop_handler()),
+    ]
 }
 
 fn inspect_claude_handler(root: &Map<String, Value>) -> Result<ClaudeHandlerState, String> {
     validate_claude_hook_shape(root)?;
-    let expected = claude_handler();
+    let expected = claude_handlers();
     let mut exact = 0usize;
+    let mut claimed = 0usize;
     let mut conflict = false;
-    if let Some(entries) = root
-        .get("hooks")
-        .and_then(Value::as_object)
-        .and_then(|hooks| hooks.get("SessionStart"))
-        .and_then(Value::as_array)
-    {
-        for entry in entries {
-            let handlers = entry
-                .get("hooks")
-                .and_then(Value::as_array)
-                .expect("validated SessionStart handler array");
-            for handler in handlers {
-                let object = handler
-                    .as_object()
-                    .expect("validated SessionStart handler object");
-                let description = object.get("description").and_then(Value::as_str);
-                let command = object.get("command").and_then(Value::as_str);
-                let claims_description = description == Some(CLAUDE_DESCRIPTION);
-                let claims_command = command.is_some_and(|command| {
-                    command.contains("tree-ring")
-                        && command.contains("integrations preflight")
-                        && command.contains("--harness claude-code")
-                });
-                if claims_description || claims_command {
-                    if handler == &expected {
-                        exact += 1;
-                    } else {
-                        conflict = true;
+    for (event, expected_handler) in &expected {
+        if let Some(entries) = root
+            .get("hooks")
+            .and_then(Value::as_object)
+            .and_then(|hooks| hooks.get(*event))
+            .and_then(Value::as_array)
+        {
+            for entry in entries {
+                let handlers = entry
+                    .get("hooks")
+                    .and_then(Value::as_array)
+                    .expect("validated Claude lifecycle handler array");
+                for handler in handlers {
+                    let object = handler
+                        .as_object()
+                        .expect("validated Claude lifecycle handler object");
+                    let description = object.get("description").and_then(Value::as_str);
+                    let command = object.get("command").and_then(Value::as_str);
+                    let claims_description = matches!(
+                        description,
+                        Some(
+                            CLAUDE_DESCRIPTION
+                                | CLAUDE_SUBAGENT_DESCRIPTION
+                                | CLAUDE_STOP_DESCRIPTION
+                                | CLAUDE_SUBAGENT_STOP_DESCRIPTION
+                        )
+                    );
+                    let claims_command = command.is_some_and(|command| {
+                        command.contains("tree-ring") && command.contains("--harness claude-code")
+                    });
+                    if claims_description || claims_command {
+                        claimed += 1;
+                        if handler == expected_handler {
+                            exact += 1;
+                        } else {
+                            conflict = true;
+                        }
                     }
                 }
             }
         }
     }
-    if conflict || exact > 1 {
+    if conflict || claimed > expected.len() || (claimed != 0 && exact != expected.len()) {
         Ok(ClaudeHandlerState::Conflict)
-    } else if exact == 1 {
+    } else if exact == expected.len() {
         Ok(ClaudeHandlerState::Exact)
     } else {
         Ok(ClaudeHandlerState::Absent)
@@ -2302,27 +2437,30 @@ fn validate_claude_hook_shape(root: &Map<String, Value>) -> Result<(), String> {
     let hooks = hooks
         .as_object()
         .ok_or_else(|| "Claude settings hooks must be an object".to_string())?;
-    if let Some(session_start) = hooks.get("SessionStart") {
-        let entries = session_start
+    for event in ["SessionStart", "SubagentStart", "Stop", "SubagentStop"] {
+        let Some(event_value) = hooks.get(event) else {
+            continue;
+        };
+        let entries = event_value
             .as_array()
-            .ok_or_else(|| "Claude SessionStart hooks must be an array".to_string())?;
+            .ok_or_else(|| format!("Claude {event} hooks must be an array"))?;
         for entry in entries {
             let entry = entry
                 .as_object()
-                .ok_or_else(|| "Claude SessionStart entry must be an object".to_string())?;
+                .ok_or_else(|| format!("Claude {event} entry must be an object"))?;
             let handlers = entry
                 .get("hooks")
                 .and_then(Value::as_array)
-                .ok_or_else(|| "Claude SessionStart entry hooks must be an array".to_string())?;
+                .ok_or_else(|| format!("Claude {event} entry hooks must be an array"))?;
             if handlers.iter().any(|handler| !handler.is_object()) {
-                return Err("Claude SessionStart command handler must be an object".to_string());
+                return Err(format!("Claude {event} command handler must be an object"));
             }
         }
     }
     Ok(())
 }
 
-fn insert_claude_handler(root: &mut Map<String, Value>, handler: Value) -> Result<(), String> {
+fn insert_claude_handlers(root: &mut Map<String, Value>) -> Result<(), String> {
     if !root.contains_key("hooks") {
         root.insert("hooks".to_string(), Value::Object(Map::new()));
     }
@@ -2330,15 +2468,56 @@ fn insert_claude_handler(root: &mut Map<String, Value>, handler: Value) -> Resul
         .get_mut("hooks")
         .and_then(Value::as_object_mut)
         .ok_or_else(|| "Claude settings hooks must be an object".to_string())?;
-    if !hooks.contains_key("SessionStart") {
-        hooks.insert("SessionStart".to_string(), Value::Array(Vec::new()));
+    for (event, handler) in claude_handlers() {
+        if !hooks.contains_key(event) {
+            hooks.insert(event.to_string(), Value::Array(Vec::new()));
+        }
+        let entries = hooks
+            .get_mut(event)
+            .and_then(Value::as_array_mut)
+            .ok_or_else(|| format!("Claude {event} hooks must be an array"))?;
+        entries.push(json!({"matcher": "", "hooks": [handler]}));
     }
-    let session_start = hooks
-        .get_mut("SessionStart")
-        .and_then(Value::as_array_mut)
-        .ok_or_else(|| "Claude SessionStart hooks must be an array".to_string())?;
-    session_start.push(json!({"matcher": "", "hooks": [handler]}));
     Ok(())
+}
+
+fn replace_legacy_claude_handlers(root: &mut Map<String, Value>) -> Result<bool, String> {
+    let legacy = legacy_claude_handlers();
+    let Some(hooks) = root.get_mut("hooks").and_then(Value::as_object_mut) else {
+        return Ok(false);
+    };
+    let mut removed = 0usize;
+    for (event, expected_handler) in &legacy {
+        let Some(entries) = hooks.get_mut(*event).and_then(Value::as_array_mut) else {
+            return Ok(false);
+        };
+        for entry in entries.iter_mut() {
+            let Some(handlers) = entry.get_mut("hooks").and_then(Value::as_array_mut) else {
+                continue;
+            };
+            handlers.retain(|handler| {
+                let matches = handler == expected_handler;
+                if matches {
+                    removed += 1;
+                }
+                !matches
+            });
+        }
+        entries.retain(|entry| {
+            entry
+                .get("hooks")
+                .and_then(Value::as_array)
+                .is_none_or(|handlers| !handlers.is_empty())
+        });
+        if entries.is_empty() {
+            hooks.remove(*event);
+        }
+    }
+    if removed != legacy.len() {
+        return Ok(false);
+    }
+    insert_claude_handlers(root)?;
+    Ok(true)
 }
 
 fn remove_claude_handler(bytes: &[u8], expected_hash: &str) -> Result<Option<Vec<u8>>, String> {
@@ -2349,40 +2528,42 @@ fn remove_claude_handler(bytes: &[u8], expected_hash: &str) -> Result<Option<Vec
     if validate_claude_hook_shape(&root).is_err() {
         return Ok(None);
     }
+    let expected = claude_handlers();
+    if sha256(&serde_json::to_vec(&expected).map_err(json_error)?) != expected_hash {
+        return Ok(None);
+    }
     let Some(hooks) = root.get_mut("hooks").and_then(Value::as_object_mut) else {
         return Ok(None);
     };
-    let Some(entries) = hooks.get_mut("SessionStart").and_then(Value::as_array_mut) else {
-        return Ok(None);
-    };
     let mut removed = 0usize;
-    for entry in entries.iter_mut() {
-        let Some(handlers) = entry.get_mut("hooks").and_then(Value::as_array_mut) else {
-            continue;
+    for (event, expected_handler) in expected {
+        let Some(entries) = hooks.get_mut(event).and_then(Value::as_array_mut) else {
+            return Ok(None);
         };
-        handlers.retain(|handler| {
-            let matches = handler.get("description").and_then(Value::as_str)
-                == Some(CLAUDE_DESCRIPTION)
-                && serde_json::to_vec(handler)
-                    .map(|bytes| sha256(&bytes) == expected_hash)
-                    .unwrap_or(false);
-            if matches {
-                removed += 1;
-            }
-            !matches
+        for entry in entries.iter_mut() {
+            let Some(handlers) = entry.get_mut("hooks").and_then(Value::as_array_mut) else {
+                continue;
+            };
+            handlers.retain(|handler| {
+                let matches = handler == &expected_handler;
+                if matches {
+                    removed += 1;
+                }
+                !matches
+            });
+        }
+        entries.retain(|entry| {
+            entry
+                .get("hooks")
+                .and_then(Value::as_array)
+                .is_none_or(|handlers| !handlers.is_empty())
         });
+        if entries.is_empty() {
+            hooks.remove(event);
+        }
     }
-    if removed != 1 {
+    if removed != 4 {
         return Ok(None);
-    }
-    entries.retain(|entry| {
-        entry
-            .get("hooks")
-            .and_then(Value::as_array)
-            .is_none_or(|handlers| !handlers.is_empty())
-    });
-    if entries.is_empty() {
-        hooks.remove("SessionStart");
     }
     if hooks.is_empty() {
         root.remove("hooks");
@@ -3005,7 +3186,7 @@ mod tests {
                 .as_array()
                 .unwrap()
                 .len(),
-            2
+            3
         );
         for owned in serialized["harnesses"]["codex"]["owned_files"]
             .as_array()
@@ -3502,6 +3683,43 @@ mod tests {
     }
 
     #[test]
+    fn exact_legacy_claude_bundle_upgrades_without_touching_user_settings() {
+        let mut root = json!({
+            "permissions": {"allow": ["Read"]},
+            "hooks": {
+                "SessionStart": [],
+                "SubagentStart": [],
+                "PreToolUse": [{"matcher": "Bash", "hooks": [{"type": "command", "command": "keep-me"}]}]
+            }
+        })
+        .as_object()
+        .unwrap()
+        .clone();
+        for (event, handler) in legacy_claude_handlers() {
+            root.get_mut("hooks")
+                .and_then(Value::as_object_mut)
+                .and_then(|hooks| hooks.get_mut(event))
+                .and_then(Value::as_array_mut)
+                .unwrap()
+                .push(json!({"matcher": "", "hooks": [handler]}));
+        }
+
+        assert!(replace_legacy_claude_handlers(&mut root).unwrap());
+
+        assert_eq!(
+            inspect_claude_handler(&root).unwrap(),
+            ClaudeHandlerState::Exact
+        );
+        assert_eq!(root["permissions"]["allow"][0], "Read");
+        assert_eq!(
+            root["hooks"]["PreToolUse"][0]["hooks"][0]["command"],
+            "keep-me"
+        );
+        assert!(root["hooks"]["Stop"].is_array());
+        assert!(root["hooks"]["SubagentStop"].is_array());
+    }
+
+    #[test]
     fn unsafe_or_unexpected_plan_paths_are_rejected_before_writes() {
         let (_temp, project, mut manifest) = fixture();
         for path in ["../outside", "/tmp/outside", "AGENTS.md"] {
@@ -3656,7 +3874,7 @@ mod tests {
     }
 
     #[test]
-    fn claude_only_plans_handlers_in_the_exact_session_start_hook_location() {
+    fn claude_only_plans_handlers_in_the_exact_lifecycle_hook_locations() {
         let (_temp, project, mut manifest) = fixture();
         let settings = project.project_root.join(".claude/settings.json");
         write(

--- a/crates/tree-ring-memory-cli/src/activation/launcher.rs
+++ b/crates/tree-ring-memory-cli/src/activation/launcher.rs
@@ -137,18 +137,17 @@ where
     S: ClaudeSpawner,
     C: FnOnce(&ProjectFs, &str) -> Result<(), LaunchError>,
 {
-    if adapter_capability(&request.harness_id) != Some(AdapterCapability::WrapperPreflight) {
+    if request.harness_id != "claude-code"
+        || !matches!(
+            adapter_capability(&request.harness_id),
+            Some(AdapterCapability::WrapperPreflight | AdapterCapability::NativePreflight)
+        )
+    {
         return Err(LaunchError::new(format!(
             "harness {} does not provide a wrapper preflight",
             request.harness_id
         )));
     }
-    if request.harness_id != "claude-code" {
-        return Err(LaunchError::new(
-            "only the Claude Code wrapper is supported",
-        ));
-    }
-
     let prepared = prepare_preflight(
         store,
         project,
@@ -299,8 +298,8 @@ mod tests {
         fs::create_dir_all(&project.memory_root).unwrap();
         let mut activation = HarnessActivation {
             state: ActivationState::ConfiguredAwaitingProof,
-            adapter_capability: AdapterCapability::WrapperPreflight,
-            adapter_version: "1".to_string(),
+            adapter_capability: AdapterCapability::NativePreflight,
+            adapter_version: "3".to_string(),
             bridge_fingerprint: String::new(),
             bridge_path: Some(".claude/skills/tree-ring-memory/SKILL.md".to_string()),
             owned_files: vec![OwnedBridgeFile {
@@ -623,7 +622,7 @@ mod tests {
             .harnesses
             .get_mut("claude-code")
             .unwrap()
-            .adapter_capability = AdapterCapability::NativePreflight;
+            .adapter_capability = AdapterCapability::WrapperPreflight;
         spawner.on_spawn = Some(Box::new(move || {
             save_manifest(&memory_root, &changed).unwrap();
         }));
@@ -656,7 +655,7 @@ mod tests {
             .harnesses
             .get_mut("claude-code")
             .unwrap()
-            .adapter_capability = AdapterCapability::NativePreflight;
+            .adapter_capability = AdapterCapability::WrapperPreflight;
         spawner.on_spawn = Some(Box::new(move || {
             save_manifest(&memory_root, &changed).unwrap();
         }));

--- a/crates/tree-ring-memory-cli/src/activation/lifecycle.rs
+++ b/crates/tree-ring-memory-cli/src/activation/lifecycle.rs
@@ -1,0 +1,348 @@
+use super::{
+    adapters::ActivationProject,
+    manifest::fingerprint,
+    preflight::{PreflightRequest, PreflightResponse},
+    SessionIdentity,
+};
+use serde_json::{json, Map, Value};
+use std::path::Path;
+use tree_ring_memory_core::SensitivityGuard;
+use uuid::Uuid;
+
+const MAX_HOOK_INPUT_BYTES: usize = 1024 * 1024;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LifecycleHookEvent {
+    SessionStart,
+    SubagentStart,
+    Stop,
+    SubagentStop,
+}
+
+impl LifecycleHookEvent {
+    fn parse(value: &str) -> Result<Self, String> {
+        match value {
+            "SessionStart" => Ok(Self::SessionStart),
+            "SubagentStart" => Ok(Self::SubagentStart),
+            "Stop" => Ok(Self::Stop),
+            "SubagentStop" => Ok(Self::SubagentStop),
+            _ => Err("unsupported lifecycle hook event".to_string()),
+        }
+    }
+
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::SessionStart => "SessionStart",
+            Self::SubagentStart => "SubagentStart",
+            Self::Stop => "Stop",
+            Self::SubagentStop => "SubagentStop",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CaptureCheckpoint {
+    pub identity: SessionIdentity,
+    pub project: String,
+    pub checkpoint_id: String,
+    pub stop_hook_active: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LifecycleHookRequest {
+    pub event: LifecycleHookEvent,
+    pub preflight: Option<PreflightRequest>,
+    pub capture_checkpoint: Option<CaptureCheckpoint>,
+}
+
+/// Normalizes only stable, harness-owned lifecycle fields. Transcript paths,
+/// model output, prompts, and arbitrary extension fields are deliberately
+/// ignored and therefore cannot enter recall queries or activation receipts.
+pub fn parse_lifecycle_hook(
+    project: &ActivationProject,
+    harness_id: &str,
+    input: &str,
+) -> Result<LifecycleHookRequest, String> {
+    if input.len() > MAX_HOOK_INPUT_BYTES {
+        return Err("lifecycle hook stdin exceeds 1 MiB".to_string());
+    }
+    if !matches!(harness_id, "codex" | "claude-code") {
+        return Err("unknown lifecycle hook harness".to_string());
+    }
+    let value: Value =
+        serde_json::from_str(input).map_err(|_| "invalid lifecycle hook stdin".to_string())?;
+    let object = value
+        .as_object()
+        .ok_or_else(|| "invalid lifecycle hook stdin".to_string())?;
+    reject_capability_fields(object)?;
+
+    let event = LifecycleHookEvent::parse(required_string(object, "hook_event_name")?)?;
+    let cwd = Path::new(required_string(object, "cwd")?);
+    ensure_cwd_inside_project(project, cwd)?;
+    let parent_session = normalized("session", required_string(object, "session_id")?);
+
+    let identity = match event {
+        LifecycleHookEvent::SessionStart | LifecycleHookEvent::Stop => SessionIdentity {
+            agent_profile: harness_id.to_string(),
+            workflow_id: parent_session.clone(),
+            session_id: parent_session,
+        },
+        LifecycleHookEvent::SubagentStart | LifecycleHookEvent::SubagentStop => {
+            let agent_id = required_string(object, "agent_id")?;
+            let agent_type = normalized("agent-type", required_string(object, "agent_type")?);
+            SessionIdentity {
+                agent_profile: format!(
+                    "{harness_id}:{agent_type}:{}",
+                    &fingerprint(agent_id)[..16]
+                ),
+                workflow_id: parent_session,
+                session_id: normalized("agent", agent_id),
+            }
+        }
+    };
+
+    let (preflight, capture_checkpoint) = match event {
+        LifecycleHookEvent::SessionStart | LifecycleHookEvent::SubagentStart => (
+            Some(PreflightRequest::lifecycle_hook(
+                harness_id,
+                identity.clone(),
+            )),
+            None,
+        ),
+        LifecycleHookEvent::Stop | LifecycleHookEvent::SubagentStop => {
+            let stop_hook_active = object
+                .get("stop_hook_active")
+                .and_then(Value::as_bool)
+                .ok_or_else(|| "invalid lifecycle hook stdin".to_string())?;
+            let project_name = project
+                .project_root
+                .file_name()
+                .and_then(|name| name.to_str())
+                .filter(|name| !name.trim().is_empty())
+                .unwrap_or("project");
+            (
+                None,
+                Some(CaptureCheckpoint {
+                    identity,
+                    project: normalized("project", project_name),
+                    checkpoint_id: Uuid::new_v4().hyphenated().to_string(),
+                    stop_hook_active,
+                }),
+            )
+        }
+    };
+
+    Ok(LifecycleHookRequest {
+        event,
+        preflight,
+        capture_checkpoint,
+    })
+}
+
+pub fn render_lifecycle_hook(
+    event: LifecycleHookEvent,
+    response: &PreflightResponse,
+) -> Result<String, String> {
+    serde_json::to_string(&json!({
+        "hookSpecificOutput": {
+            "hookEventName": event.as_str(),
+            "additionalContext": response.context,
+        }
+    }))
+    .map_err(|_| "failed to serialize lifecycle hook context".to_string())
+}
+
+pub fn render_capture_checkpoint(checkpoint: &CaptureCheckpoint) -> Result<String, String> {
+    if checkpoint.stop_hook_active {
+        return Ok("{}".to_string());
+    }
+    let identity = &checkpoint.identity;
+    let reason = format!(
+        "Tree Ring automatic capture checkpoint {checkpoint_id}. Before stopping, review only the durable outcomes already available in your working context. For zero to three genuinely reusable normal-sensitivity preferences, decisions, validated lessons, warnings, corrections, or future seeds, run one strict capture command per candidate:\nproject_root=\"$(git rev-parse --show-toplevel 2>/dev/null || pwd)\"; tree-ring --root \"$project_root/.tree-ring\" capture \"<concise summary>\" --event-type <preference|decision|lesson|warning|correction|seed> --ring <cambium|scar|seed> --project \"{project}\" --agent-profile \"{agent_profile}\" --workflow-id \"{workflow_id}\" --session-id \"{session_id}\" --operation-id auto-{checkpoint_id}-<1|2|3> --source-ref agent-checkpoint:{checkpoint_id}\nUse the same indexed operation ID only when retrying that same candidate. Use only `tree-ring capture` for this automatic checkpoint; `remember` and `evidence` remain separate manual surfaces. If nothing durable occurred, write nothing and finish; never invent memory. Never store raw prompts, transcripts, tool logs, secrets, or sensitive data, and do not start a background recorder. After this checkpoint, finish the response.",
+        checkpoint_id = checkpoint.checkpoint_id,
+        project = checkpoint.project,
+        agent_profile = identity.agent_profile,
+        workflow_id = identity.workflow_id,
+        session_id = identity.session_id,
+    );
+    serde_json::to_string(&json!({
+        "decision": "block",
+        "reason": reason,
+    }))
+    .map_err(|_| "failed to serialize automatic capture checkpoint".to_string())
+}
+
+fn required_string<'a>(object: &'a Map<String, Value>, name: &str) -> Result<&'a str, String> {
+    object
+        .get(name)
+        .and_then(Value::as_str)
+        .filter(|value| !value.trim().is_empty())
+        .ok_or_else(|| "invalid lifecycle hook stdin".to_string())
+}
+
+fn normalized(label: &str, value: &str) -> String {
+    if value.len() <= 128
+        && value
+            .chars()
+            .all(|character| character.is_ascii_alphanumeric() || "-_.:@".contains(character))
+        && !matches!(value, "." | "..")
+        && SensitivityGuard::default().inspect(value).sensitivity == "normal"
+    {
+        value.to_string()
+    } else {
+        format!("{label}-{}", &fingerprint(value)[..24])
+    }
+}
+
+fn ensure_cwd_inside_project(project: &ActivationProject, cwd: &Path) -> Result<(), String> {
+    let project_root = std::fs::canonicalize(&project.project_root)
+        .map_err(|_| "lifecycle hook project root unavailable".to_string())?;
+    let cwd =
+        std::fs::canonicalize(cwd).map_err(|_| "lifecycle hook cwd unavailable".to_string())?;
+    if cwd == project_root || cwd.starts_with(&project_root) {
+        Ok(())
+    } else {
+        Err("lifecycle hook cwd is outside the project".to_string())
+    }
+}
+
+fn reject_capability_fields(object: &Map<String, Value>) -> Result<(), String> {
+    const BLOCKED: &[&str] = &[
+        "authorization",
+        "capability",
+        "capabilities",
+        "coordinator_capability",
+        "memory_root",
+        "project_root",
+        "store_id",
+        "task_hint",
+    ];
+    if object.keys().any(|key| BLOCKED.contains(&key.as_str())) {
+        Err("lifecycle hook stdin contains forbidden fields".to_string())
+    } else {
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    fn fixture() -> (tempfile::TempDir, ActivationProject) {
+        let temp = tempfile::tempdir().unwrap();
+        let project = ActivationProject::from_project_root(temp.path().join("project"));
+        fs::create_dir_all(project.project_root.join("src")).unwrap();
+        (temp, project)
+    }
+
+    #[test]
+    fn session_start_derives_identity_without_reading_transcript_or_prompt() {
+        let (_temp, project) = fixture();
+        let input = json!({
+            "session_id": "thread-1",
+            "cwd": project.project_root.join("src"),
+            "hook_event_name": "SessionStart",
+            "source": "startup",
+            "transcript_path": "/private/transcript.jsonl",
+            "model": "gpt-example"
+        });
+
+        let request = parse_lifecycle_hook(&project, "codex", &input.to_string()).unwrap();
+
+        assert_eq!(request.event, LifecycleHookEvent::SessionStart);
+        let preflight = request.preflight.unwrap();
+        assert_eq!(preflight.identity.agent_profile, "codex");
+        assert_eq!(preflight.identity.workflow_id, "thread-1");
+        assert_eq!(preflight.identity.session_id, "thread-1");
+        assert!(request.capture_checkpoint.is_none());
+    }
+
+    #[test]
+    fn subagent_start_derives_distinct_worker_identity() {
+        let (_temp, project) = fixture();
+        let input = json!({
+            "session_id": "thread-1",
+            "cwd": project.project_root,
+            "hook_event_name": "SubagentStart",
+            "agent_id": "agent-2",
+            "agent_type": "reviewer"
+        });
+
+        let request = parse_lifecycle_hook(&project, "claude-code", &input.to_string()).unwrap();
+
+        assert_eq!(request.event, LifecycleHookEvent::SubagentStart);
+        let preflight = request.preflight.unwrap();
+        assert!(preflight
+            .identity
+            .agent_profile
+            .starts_with("claude-code:reviewer:"));
+        assert_eq!(preflight.identity.workflow_id, "thread-1");
+        assert_eq!(preflight.identity.session_id, "agent-2");
+        assert!(request.capture_checkpoint.is_none());
+    }
+
+    #[test]
+    fn stop_enforces_one_structured_checkpoint_without_reading_model_output() {
+        let (_temp, project) = fixture();
+        let private_output = "private assistant output that must not be captured";
+        let input = json!({
+            "session_id": "thread-1",
+            "cwd": project.project_root,
+            "hook_event_name": "Stop",
+            "stop_hook_active": false,
+            "last_assistant_message": private_output,
+            "transcript_path": "/private/transcript.jsonl"
+        });
+
+        let request = parse_lifecycle_hook(&project, "codex", &input.to_string()).unwrap();
+        let checkpoint = request.capture_checkpoint.unwrap();
+        let rendered = render_capture_checkpoint(&checkpoint).unwrap();
+
+        assert_eq!(request.event, LifecycleHookEvent::Stop);
+        assert!(request.preflight.is_none());
+        assert!(rendered.contains("\"decision\":\"block\""));
+        assert!(rendered.contains(" tree-ring --root "));
+        assert!(rendered.contains(" capture "));
+        assert!(!rendered.contains("--scope"));
+        assert!(!rendered.contains(private_output));
+        assert!(!rendered.contains("transcript.jsonl"));
+    }
+
+    #[test]
+    fn active_stop_checkpoint_allows_completion_without_a_loop() {
+        let (_temp, project) = fixture();
+        let input = json!({
+            "session_id": "thread-1",
+            "cwd": project.project_root,
+            "hook_event_name": "SubagentStop",
+            "stop_hook_active": true,
+            "agent_id": "agent-2",
+            "agent_type": "reviewer"
+        });
+
+        let request = parse_lifecycle_hook(&project, "claude-code", &input.to_string()).unwrap();
+        let checkpoint = request.capture_checkpoint.unwrap();
+
+        assert_eq!(request.event, LifecycleHookEvent::SubagentStop);
+        assert!(checkpoint
+            .identity
+            .agent_profile
+            .starts_with("claude-code:reviewer:"));
+        assert_eq!(render_capture_checkpoint(&checkpoint).unwrap(), "{}");
+    }
+
+    #[test]
+    fn hook_rejects_model_supplied_roots_and_capabilities() {
+        let (_temp, project) = fixture();
+        let input = json!({
+            "session_id": "thread-1",
+            "cwd": project.project_root,
+            "hook_event_name": "SessionStart",
+            "memory_root": "/tmp/other"
+        });
+
+        let error = parse_lifecycle_hook(&project, "codex", &input.to_string()).unwrap_err();
+        assert_eq!(error, "lifecycle hook stdin contains forbidden fields");
+    }
+}

--- a/crates/tree-ring-memory-cli/src/activation/manifest.rs
+++ b/crates/tree-ring-memory-cli/src/activation/manifest.rs
@@ -638,7 +638,7 @@ fn allowed_owned_file(harness_id: &str, path: &str) -> bool {
     match harness_id {
         "codex" => matches!(
             path,
-            ".agents/skills/tree-ring-memory/SKILL.md" | "AGENTS.md"
+            ".agents/skills/tree-ring-memory/SKILL.md" | ".codex/hooks.json" | "AGENTS.md"
         ),
         "claude-code" => matches!(
             path,

--- a/crates/tree-ring-memory-cli/src/activation/mod.rs
+++ b/crates/tree-ring-memory-cli/src/activation/mod.rs
@@ -37,9 +37,14 @@ pub struct SessionIdentity {
 pub mod adapters;
 pub mod bridge;
 pub mod launcher;
+pub mod lifecycle;
 pub mod manifest;
 pub mod preflight;
 
+pub use lifecycle::{
+    parse_lifecycle_hook, render_capture_checkpoint, render_lifecycle_hook, CaptureCheckpoint,
+    LifecycleHookEvent, LifecycleHookRequest,
+};
 #[allow(unused_imports)]
 pub use manifest::{
     load_manifest, load_or_create_manifest, prune_receipts, write_receipt, ActivationManifest,

--- a/crates/tree-ring-memory-cli/src/activation/preflight.rs
+++ b/crates/tree-ring-memory-cli/src/activation/preflight.rs
@@ -54,6 +54,7 @@ enum PreflightInputContract {
     DirectIdentityFlags,
     AdapterStdin,
     ClaudeWrapper,
+    LifecycleHook,
 }
 
 impl PreflightRequest {
@@ -103,6 +104,18 @@ impl PreflightRequest {
             task_hint,
             context_format: PreflightContextFormat::Json,
             input_contract: PreflightInputContract::ClaudeWrapper,
+        }
+    }
+
+    /// Constructs a request from a validated, harness-owned lifecycle event.
+    /// Callers must sanitize the vendor payload before crossing this boundary.
+    pub(crate) fn lifecycle_hook(harness_id: impl Into<String>, identity: SessionIdentity) -> Self {
+        Self {
+            harness_id: harness_id.into(),
+            identity,
+            task_hint: None,
+            context_format: PreflightContextFormat::Json,
+            input_contract: PreflightInputContract::LifecycleHook,
         }
     }
 }
@@ -625,6 +638,10 @@ fn validate_request_contract(request: &PreflightRequest) -> Result<(), Activatio
                 && request.identity.agent_profile == "claude-code"
                 && request.identity.workflow_id.starts_with("claude-launch-")
                 && request.identity.session_id.starts_with("claude-session-")
+        }
+        PreflightInputContract::LifecycleHook => {
+            matches!(request.harness_id.as_str(), "codex" | "claude-code")
+                && request.context_format == PreflightContextFormat::Json
         }
     };
     valid

--- a/crates/tree-ring-memory-cli/src/agent_awareness.rs
+++ b/crates/tree-ring-memory-cli/src/agent_awareness.rs
@@ -27,6 +27,9 @@ const SKILL_RUNTIME_ANCHOR: &str = "## When To Recall";
 const CLI_RUNTIME_HEADING: &str = "Runtime bootstrap and updates:";
 const CLI_RUNTIME_ANCHOR: &str = "Core commands:";
 const PREFLIGHT_HEADING: &str = "## Harness Preflight";
+const AGENT_CAPTURE_HEADING: &str = "## Automatic Capture Checkpoint";
+const SKILL_CAPTURE_HEADING: &str = "## Automatic Capture Checkpoint";
+const CLI_CAPTURE_HEADING: &str = "Automatic capture checkpoint:";
 const PREFLIGHT_GUIDANCE: &str = r#"## Harness Preflight
 
 Before substantive project work in a new harness session, read this canonical
@@ -71,6 +74,7 @@ tree-ring init
 tree-ring update --check
 tree-ring recall "project startup warnings"
 tree-ring remember "Use project-scoped recall before risky changes." --event-type lesson --scope project
+tree-ring capture "Use bounded lifecycle checkpoints." --event-type decision --ring cambium --project example --agent-profile worker --workflow-id workflow --session-id session --operation-id auto-checkpoint-1 --source-ref agent-checkpoint:checkpoint
 tree-ring evidence "Snapshot invalidation fixed stale unread chat state." --outcome promoted --evidence-ref evals/chat-state/run-042 --score 0.91
 tree-ring evidence "Aggressive caching caused stale multi-chat state." --outcome rejected --evidence-ref evals/cache-branch/run-013
 tree-ring forget mem_example --mode redact --reason "remove sensitive detail"
@@ -117,6 +121,14 @@ Coordinated write policy:
 - `tree-ring policy status` and `tree-ring policy audit --limit 100` are read-only. Rotate with `tree-ring policy rotate --coordinator <label>` and return to Open mode with `tree-ring policy disable`; both require the current capability.
 - This is operational write authorization in official Rust/CLI paths, not a read ACL or protection against an adversary who controls the local files or process environment.
 - Before opening a pre-v0.13 store with a v0.13/schema-v3 binary, stop every Tree Ring process, checkpoint and back up the store, and upgrade every CLI, plugin, and bundled worker. Schema v3 fences memory inserts, updates, and deletes from old v0.12 writers; all mixed-version operation is unsupported. Roll back only by restoring the backup.
+
+Automatic capture checkpoint:
+
+- Maintained Codex and Claude lifecycle bridges enforce one checkpoint at `Stop` and `SubagentStop`; Agent Zero injects the same checkpoint contract through its native prompt lifecycle.
+- Select zero to three concise durable normal-sensitivity candidates. Zero is correct for transient chatter, duplicates, unsupported claims, or work with no reusable outcome.
+- Use `tree-ring capture` only with the lifecycle-supplied project, agent, workflow, session, indexed operation ID, and `agent-checkpoint:` source. The command fixes scope to `agent` and permits only cambium, scar, or seed candidates.
+- Use only `tree-ring capture` for this automatic checkpoint. Manual `remember` and `evidence` remain separate surfaces and never bypass coordinated write policy.
+- Never derive automatic memory from raw prompts, transcripts, or tool logs, and never start a background recorder.
 
 Memory quality gates:
 
@@ -237,9 +249,42 @@ pub fn ensure_agent_awareness(root: &Path) -> Result<AgentAwarenessReport, Strin
     maybe_backfill_generated_file(
         &root.join("AGENTS.md"),
         is_generated_agents_file,
+        AGENT_CAPTURE_HEADING,
+        AGENT_QUALITY_GATES_HEADING,
+        extract_section(
+            &agent_contract,
+            AGENT_CAPTURE_HEADING,
+            AGENT_QUALITY_GATES_HEADING,
+        ),
+    )?;
+    maybe_backfill_generated_file(
+        &root.join("AGENTS.md"),
+        is_generated_agents_file,
         PREFLIGHT_HEADING,
         AGENT_QUALITY_GATES_HEADING,
         Some(PREFLIGHT_GUIDANCE),
+    )?;
+    maybe_backfill_generated_file(
+        &root.join("SKILL.md"),
+        is_generated_skill_file,
+        SKILL_CAPTURE_HEADING,
+        SKILL_QUALITY_GATES_HEADING,
+        extract_section(
+            SKILL_TEMPLATE,
+            SKILL_CAPTURE_HEADING,
+            SKILL_QUALITY_GATES_HEADING,
+        ),
+    )?;
+    maybe_backfill_generated_file(
+        &root.join("CLI.md"),
+        is_generated_cli_file,
+        CLI_CAPTURE_HEADING,
+        CLI_QUALITY_GATES_HEADING,
+        extract_section(
+            CLI_REFERENCE,
+            CLI_CAPTURE_HEADING,
+            CLI_QUALITY_GATES_HEADING,
+        ),
     )?;
     maybe_backfill_generated_file(
         &root.join("SKILL.md"),
@@ -453,7 +498,10 @@ user opt-in configuration.
 Tree Ring Memory is agent-mediated. Bridge files tell the active agent when to
 call `tree-ring recall`, `tree-ring remember`, `tree-ring evidence`,
 `tree-ring forget`, `tree-ring consolidate --dry-run`, or `tree-ring maintain`.
-They do not authorize hidden transcript scraping or autonomous durable writes.
+Maintained lifecycle bridges also enforce one strict automatic capture
+checkpoint through `tree-ring capture`. They do not authorize transcript
+scraping, hidden recording, shared automatic writes, or bypassing quality and
+coordinated-policy gates.
 
 ## Multi-Agent Coordination
 
@@ -519,6 +567,22 @@ and bundled worker before reopening it. Schema v3 rejects memory inserts,
 updates, and deletes from old v0.12 writers; all mixed-version operation is
 unsupported. Roll back only by stopping all processes and restoring the
 pre-upgrade backup.
+
+## Automatic Capture Checkpoint
+
+Maintained Codex and Claude bridges enforce one checkpoint at `Stop` and
+`SubagentStop`; Agent Zero injects the same contract through its native prompt
+lifecycle. Review only outcomes already available in working context and select
+zero to three concise durable normal-sensitivity candidates. Zero is correct
+when nothing reusable occurred.
+
+Use `tree-ring --root {root} capture` only with the lifecycle-supplied project,
+agent, workflow, session, indexed operation ID, and `agent-checkpoint:` source.
+Automatic capture is always agent-scoped and permits only cambium, scar, or
+seed candidates. Use only `tree-ring capture` for this automatic checkpoint;
+manual `remember` and `evidence` remain separate surfaces. Never store raw prompts,
+transcripts, tool logs, secrets, or sensitive data. Never start a background recorder,
+and never claim a capture unless the write command succeeds.
 
 ## Memory Quality Gates
 
@@ -714,6 +778,53 @@ mod tests {
             assert!(content.contains("recall \"project startup constraints\""));
             assert!(content.contains("does not create activation proof"));
             assert!(content.contains("not an adversarial security boundary"));
+        }
+    }
+
+    #[test]
+    fn generated_files_backfill_the_strict_automatic_capture_checkpoint() {
+        let dir = tempdir().unwrap();
+        let root = dir.path().join(".tree-ring");
+        fs::create_dir_all(&root).unwrap();
+        let canonical_agents = agent_contract(&root);
+
+        for (name, canonical, heading, anchor) in [
+            (
+                "AGENTS.md",
+                canonical_agents.as_str(),
+                AGENT_CAPTURE_HEADING,
+                AGENT_QUALITY_GATES_HEADING,
+            ),
+            (
+                "SKILL.md",
+                SKILL_TEMPLATE,
+                SKILL_CAPTURE_HEADING,
+                SKILL_QUALITY_GATES_HEADING,
+            ),
+            (
+                "CLI.md",
+                CLI_REFERENCE,
+                CLI_CAPTURE_HEADING,
+                CLI_QUALITY_GATES_HEADING,
+            ),
+        ] {
+            let mut stale = stale_fixture(canonical, heading, anchor);
+            stale.push_str("\nCustom project note: preserve me.\n");
+            fs::write(root.join(name), stale).unwrap();
+        }
+
+        ensure_agent_awareness(&root).unwrap();
+
+        for name in ["AGENTS.md", "SKILL.md", "CLI.md"] {
+            let content = fs::read_to_string(root.join(name)).unwrap();
+            assert!(
+                content.contains("Automatic Capture Checkpoint")
+                    || content.contains("Automatic capture checkpoint:")
+            );
+            assert!(content.contains("tree-ring capture"));
+            assert!(content.contains("zero to three"));
+            assert!(content.contains("background recorder"));
+            assert!(content.contains("Custom project note: preserve me."));
         }
     }
 

--- a/crates/tree-ring-memory-cli/src/main.rs
+++ b/crates/tree-ring-memory-cli/src/main.rs
@@ -30,7 +30,10 @@ use actions::lifecycle::{
     MaintainActionRequest,
 };
 use actions::recall::{recall as recall_action, RecallRequest};
-use actions::remember::{remember as remember_action, store_event_idempotently, RememberRequest};
+use actions::remember::{
+    capture as capture_action, remember as remember_action, store_event_idempotently,
+    CaptureRequest, RememberRequest,
+};
 use harness_evidence::{
     certify_harnesses, HarnessCertificationReport, HarnessCertificationRequest,
 };
@@ -123,6 +126,28 @@ enum Command {
             help = "source artifact, task, run, message, or result reference"
         )]
         source_ref: Option<String>,
+        #[arg(long = "tag")]
+        tags: Vec<String>,
+    },
+    #[command(about = "store one strict agent-mediated automatic memory candidate")]
+    Capture {
+        summary: String,
+        #[arg(long)]
+        event_type: String,
+        #[arg(long, default_value = "cambium")]
+        ring: String,
+        #[arg(long)]
+        project: String,
+        #[arg(long)]
+        agent_profile: String,
+        #[arg(long)]
+        workflow_id: String,
+        #[arg(long)]
+        session_id: String,
+        #[arg(long)]
+        operation_id: String,
+        #[arg(long)]
+        source_ref: String,
         #[arg(long = "tag")]
         tags: Vec<String>,
     },
@@ -438,6 +463,13 @@ enum IntegrationCommand {
         #[arg(long, value_enum, default_value_t = CliPreflightContextFormat::Json)]
         context_format: CliPreflightContextFormat,
     },
+    #[command(about = "run a validated harness lifecycle hook and emit context")]
+    Hook {
+        #[arg(long)]
+        harness: String,
+        #[arg(long, help = "read one harness-owned lifecycle JSON event from stdin")]
+        input_json_stdin: bool,
+    },
     #[command(about = "write non-mutating harness certification evidence")]
     Certify {
         #[arg(long, default_value = ".", help = "project root to certify")]
@@ -701,6 +733,46 @@ fn run(cli: Cli) -> Result<(), String> {
             live: *live,
         })?;
         print_harness_certification_report(&report, cli.json)?;
+        return Ok(());
+    }
+
+    if let Command::Integrations {
+        command:
+            IntegrationCommand::Hook {
+                harness,
+                input_json_stdin,
+            },
+    } = &cli.command
+    {
+        if !input_json_stdin {
+            return Err("integrations hook requires --input-json-stdin".to_string());
+        }
+        let mut input = String::new();
+        std::io::stdin()
+            .take(1024 * 1024 + 1)
+            .read_to_string(&mut input)
+            .map_err(|_| "failed to read lifecycle hook stdin".to_string())?;
+        if input.len() > 1024 * 1024 {
+            return Err("lifecycle hook stdin exceeds 1 MiB".to_string());
+        }
+        let project = activation::adapters::ActivationProject::from_memory_root(cli.root.clone())?;
+        let request = activation::parse_lifecycle_hook(&project, harness, &input)?;
+        let manifest = activation::load_manifest(&cli.root)?;
+        ensure_manifest_preflight_ready(&manifest, harness, false)?;
+        if let Some(preflight) = request.preflight {
+            let store =
+                SQLiteMemoryStore::open_read_only(&db_path).map_err(|error| error.to_string())?;
+            let response = activation::run_preflight(&store, &project, &manifest, preflight)
+                .map_err(|error| error.to_string())?;
+            println!(
+                "{}",
+                activation::render_lifecycle_hook(request.event, &response)?
+            );
+        } else if let Some(checkpoint) = request.capture_checkpoint {
+            println!("{}", activation::render_capture_checkpoint(&checkpoint)?);
+        } else {
+            return Err("lifecycle hook action unavailable".to_string());
+        }
         return Ok(());
     }
 
@@ -992,6 +1064,42 @@ fn run(cli: Cli) -> Result<(), String> {
                     event_type,
                     ring,
                     scope,
+                    project,
+                    agent_profile,
+                    workflow_id,
+                    session_id,
+                    operation_id,
+                    source_ref,
+                    tags,
+                },
+            )?;
+            if cli.json {
+                println!(
+                    "{}",
+                    serde_json::to_string(&report.memory).map_err(|err| err.to_string())?
+                );
+            } else {
+                println!("{}", report.memory.id);
+            }
+        }
+        Command::Capture {
+            summary,
+            event_type,
+            ring,
+            project,
+            agent_profile,
+            workflow_id,
+            session_id,
+            operation_id,
+            source_ref,
+            tags,
+        } => {
+            let report = capture_action(
+                &mut store,
+                CaptureRequest {
+                    summary,
+                    event_type,
+                    ring,
                     project,
                     agent_profile,
                     workflow_id,
@@ -1517,6 +1625,7 @@ fn command_actor_profile(command: &Command) -> Option<String> {
         | Command::Evidence { agent_profile, .. }
         | Command::Recall { agent_profile, .. }
         | Command::Consolidate { agent_profile, .. } => agent_profile.clone(),
+        Command::Capture { agent_profile, .. } => Some(agent_profile.clone()),
         _ => None,
     }
 }
@@ -1526,6 +1635,7 @@ fn command_origin(command: &Command) -> &'static str {
         Command::Init { .. } => "cli:init",
         Command::Update { .. } => "cli:update",
         Command::Remember { .. } => "cli:remember",
+        Command::Capture { .. } => "cli:capture",
         Command::Evidence { .. } => "cli:evidence",
         Command::Recall { .. } => "cli:recall",
         Command::Forget { .. } => "cli:forget",

--- a/crates/tree-ring-memory-cli/tests/harness_activation_acceptance.rs
+++ b/crates/tree-ring-memory-cli/tests/harness_activation_acceptance.rs
@@ -67,7 +67,11 @@ fn shipped_fixtures_declare_only_project_local_versioned_activation_contracts() 
             "codex",
             (
                 "configured-awaiting-proof",
-                vec![".agents/skills/tree-ring-memory/SKILL.md", "AGENTS.md"],
+                vec![
+                    ".agents/skills/tree-ring-memory/SKILL.md",
+                    ".codex/hooks.json",
+                    "AGENTS.md",
+                ],
             ),
         ),
         (
@@ -85,7 +89,12 @@ fn shipped_fixtures_declare_only_project_local_versioned_activation_contracts() 
     for (id, fixture) in fixture_map {
         assert_eq!(fixture["schema_version"], 1, "{id}");
         assert_eq!(fixture["harness_id"], id, "{id}");
-        assert_eq!(fixture["adapter_version"], "1", "{id}");
+        let expected_adapter_version = if matches!(id.as_str(), "codex" | "claude-code") {
+            "3"
+        } else {
+            "1"
+        };
+        assert_eq!(fixture["adapter_version"], expected_adapter_version, "{id}");
         assert_eq!(
             fixture["expected_activation_state_before_proof"],
             expected[id.as_str()].0,
@@ -164,6 +173,151 @@ fn default_relative_root_initializes_from_the_project_root() {
     assert!(project
         .join(".agents/skills/tree-ring-memory/SKILL.md")
         .exists());
+    let codex_hooks = fs::read_to_string(project.join(".codex/hooks.json")).unwrap();
+    assert!(codex_hooks.contains("SessionStart"));
+    assert!(codex_hooks.contains("SubagentStart"));
+    assert!(codex_hooks.contains("\"Stop\""));
+    assert!(codex_hooks.contains("SubagentStop"));
+    assert!(!codex_hooks.contains("UserPromptSubmit"));
+    assert!(!codex_hooks.contains("SessionEnd"));
+
+    let mut hook_child = Command::new(env!("CARGO_BIN_EXE_tree-ring"))
+        .current_dir(&project)
+        .env("PATH", OsString::from(empty_path.as_os_str()))
+        .env("HOME", project.join("fixture-home"))
+        .arg("integrations")
+        .args(["hook", "--harness", "codex", "--input-json-stdin"])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+    serde_json::to_writer(
+        hook_child.stdin.take().unwrap(),
+        &json!({
+            "session_id": "hook-session",
+            "cwd": project,
+            "hook_event_name": "SessionStart",
+            "source": "startup",
+            "transcript_path": "/private/must-not-be-read.jsonl"
+        }),
+    )
+    .unwrap();
+    let hook = hook_child.wait_with_output().unwrap();
+    assert_success("Codex lifecycle hook", &hook);
+    let hook_json = output_json("Codex lifecycle hook", &hook);
+    assert_eq!(
+        hook_json["hookSpecificOutput"]["hookEventName"],
+        "SessionStart"
+    );
+    assert!(hook_json["hookSpecificOutput"]["additionalContext"].is_string());
+
+    let mut subagent_hook_child = Command::new(env!("CARGO_BIN_EXE_tree-ring"))
+        .current_dir(&project)
+        .env("PATH", OsString::from(empty_path.as_os_str()))
+        .env("HOME", project.join("fixture-home"))
+        .arg("integrations")
+        .args(["hook", "--harness", "codex", "--input-json-stdin"])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+    serde_json::to_writer(
+        subagent_hook_child.stdin.take().unwrap(),
+        &json!({
+            "session_id": "hook-session",
+            "cwd": project,
+            "hook_event_name": "SubagentStart",
+            "agent_id": "worker-1",
+            "agent_type": "reviewer",
+            "transcript_path": "/private/must-not-be-read.jsonl"
+        }),
+    )
+    .unwrap();
+    let subagent_hook = subagent_hook_child.wait_with_output().unwrap();
+    assert_success("Codex subagent lifecycle hook", &subagent_hook);
+    let subagent_hook_json = output_json("Codex subagent lifecycle hook", &subagent_hook);
+    assert_eq!(
+        subagent_hook_json["hookSpecificOutput"]["hookEventName"],
+        "SubagentStart"
+    );
+    assert!(subagent_hook_json["hookSpecificOutput"]["additionalContext"].is_string());
+
+    let mut stop_child = Command::new(env!("CARGO_BIN_EXE_tree-ring"))
+        .current_dir(&project)
+        .env("PATH", OsString::from(empty_path.as_os_str()))
+        .env("HOME", project.join("fixture-home"))
+        .arg("integrations")
+        .args(["hook", "--harness", "codex", "--input-json-stdin"])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+    serde_json::to_writer(
+        stop_child.stdin.take().unwrap(),
+        &json!({
+            "session_id": "hook-session",
+            "cwd": project,
+            "hook_event_name": "Stop",
+            "stop_hook_active": false,
+            "last_assistant_message": "private output must stay opaque",
+            "transcript_path": "/private/must-not-be-read.jsonl"
+        }),
+    )
+    .unwrap();
+    let stop = stop_child.wait_with_output().unwrap();
+    assert_success("Codex stop checkpoint", &stop);
+    let stop_json = output_json("Codex stop checkpoint", &stop);
+    assert_eq!(stop_json["decision"], "block");
+    assert!(stop_json["reason"]
+        .as_str()
+        .unwrap()
+        .contains(" tree-ring --root "));
+    assert!(stop_json["reason"].as_str().unwrap().contains(" capture "));
+    assert!(!stop_json["reason"]
+        .as_str()
+        .unwrap()
+        .contains("private output"));
+
+    let capture = Command::new(env!("CARGO_BIN_EXE_tree-ring"))
+        .current_dir(&project)
+        .env("PATH", OsString::from(empty_path.as_os_str()))
+        .env("HOME", project.join("fixture-home"))
+        .args([
+            "--json",
+            "capture",
+            "Lifecycle capture stores only concise durable candidates.",
+            "--event-type",
+            "decision",
+            "--ring",
+            "cambium",
+            "--project",
+            "relative-default-root",
+            "--agent-profile",
+            "codex",
+            "--workflow-id",
+            "hook-session",
+            "--session-id",
+            "hook-session",
+            "--operation-id",
+            "auto-checkpoint-acceptance-1",
+            "--source-ref",
+            "agent-checkpoint:checkpoint-acceptance",
+        ])
+        .output()
+        .unwrap();
+    assert_success("strict automatic capture", &capture);
+    let captured = output_json("strict automatic capture", &capture);
+    assert_eq!(captured["scope"], "agent");
+    assert_eq!(captured["agent_profile"], "codex");
+    assert_eq!(captured["sensitivity"], "normal");
+    assert!(captured["tags"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|tag| tag == "automatic-capture"));
 
     let preflight = Command::new(env!("CARGO_BIN_EXE_tree-ring"))
         .current_dir(&project)
@@ -918,13 +1072,13 @@ fn install_agent_zero_plugin(base: &Path) -> PathBuf {
     fs::create_dir_all(&plugin).unwrap();
     fs::write(
         plugin.join("plugin.yaml"),
-        "name: tree_ring_memory\nversion: 3.3.1\n",
+        "name: tree_ring_memory\nversion: 3.4.0\n",
     )
     .unwrap();
     let descriptor = plugin.join("activation-capability.json");
     fs::write(
         &descriptor,
-        r#"{"schema_version":1,"kind":"tree-ring-agent-zero-plugin-capability","plugin_id":"tree_ring_memory","plugin_version":"3.3.1","activation_protocol_version":1,"tree_ring_version":{"min":"0.15.3","minor":"0.15"},"enabled":true}"#,
+        r#"{"schema_version":1,"kind":"tree-ring-agent-zero-plugin-capability","plugin_id":"tree_ring_memory","plugin_version":"3.4.0","activation_protocol_version":1,"tree_ring_version":{"min":"0.15.5","minor":"0.15"},"enabled":true}"#,
     )
     .unwrap();
     descriptor

--- a/docs/integrations/agent-skill.md
+++ b/docs/integrations/agent-skill.md
@@ -410,11 +410,12 @@ repo. Global bridge files under `~/.agents`, `~/.codex`, `~/.claude`,
 `~/.gemini`, or `~/.pi` affect every project and should be written only through
 an explicit global opt-in flow.
 
-The bridge-linking design is agent-mediated: bridge files teach the active
-agent when to call Tree Ring, but Tree Ring does not run a background recorder
-or autonomously persist chat transcripts. Durable writes happen only when a
-user, agent, adapter, import, TUI action, consolidation command, or explicit
-maintenance command calls the CLI.
+The bridge-linking design is agent-mediated: start hooks perform receipt-backed
+recall, and maintained stop hooks require the active agent to evaluate zero to
+three structured automatic-capture candidates. Accepted candidates still cross
+the strict CLI write boundary with lifecycle identity, idempotency, provenance,
+sensitivity filtering, and coordinated-policy enforcement. Tree Ring does not
+run a background recorder or autonomously persist chat transcripts.
 
 `integrations link` is an advanced alias for controlled bridge work; it is not
 required after default initialization. `tree-ring integrations activate --harness

--- a/docs/launch/tree-ring-memory-framework.md
+++ b/docs/launch/tree-ring-memory-framework.md
@@ -63,8 +63,11 @@ The point is not to store more. The point is to keep memory useful as it ages.
 Tree Ring Memory is local-first by default. It does not scrape transcripts, run
 a hidden recorder, or turn terminal event pulses into durable memory.
 
-Durable writes are explicit: `remember`, `evidence`, `import`, consolidation,
-maintenance, TUI action, or deliberate agent action.
+Durable writes always cross a validated action boundary: `remember`, strict
+agent-mediated lifecycle `capture`, `evidence`, `import`, consolidation,
+maintenance, or a TUI action. Automatic capture evaluates zero to three concise
+normal-sensitivity candidates at stop; it does not scrape transcripts or run a
+background recorder.
 
 ## Feedback Wanted
 

--- a/docs/protocol/harness-activation.md
+++ b/docs/protocol/harness-activation.md
@@ -213,7 +213,7 @@ Web UI/API response, or receipt.
   "protocol_version": 1,
   "receipt_id": "receipt-01",
   "harness_id": "claude-code",
-  "adapter_version": "1",
+  "adapter_version": "3",
   "bridge_fingerprint": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
   "store_id": "01234567-89ab-4def-8123-456789abcdef",
   "project_root_fingerprint": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
@@ -240,29 +240,50 @@ and persists the receipt.
 Receipt freshness is derived from `recorded_at` and the 30-day retention
 window; no expiry timestamp is serialized.
 
-### Claude Code SessionStart input
+### Codex and Claude Code lifecycle-hook input
 
-The managed Claude command consumes only this privacy-safe projection of the
-host's SessionStart event:
+The managed Codex and Claude Code commands accept exactly `SessionStart`,
+`SubagentStart`, `Stop`, and `SubagentStop`. Start hooks perform receipt-backed
+recall. Stop hooks enforce one agent-mediated automatic capture checkpoint. A
+session-start hook consumes this privacy-safe projection of the host event:
 
 ```json
 {
   "session_id": "session-01",
   "cwd": ".",
-  "agent_type": "claude-code"
+  "hook_event_name": "SessionStart",
+  "source": "startup"
 }
 ```
 
-`session_id` and `cwd` are required; `agent_type` is optional and defaults
-to `claude-code`. `cwd` is resolved by the running hook and is not copied into
-a receipt. Claude may include `transcript_path` in its original event, but Tree
-Ring ignores it completely: it is not read, forwarded, logged, persisted, or
-included in recall. No other event field is part of the preflight request.
+`session_id`, `cwd`, and `hook_event_name` are required. `source` is host
+metadata and is ignored after the host has selected the hook. `cwd` must resolve
+inside the activated project and is not copied into a receipt. Compaction is
+rehydrated by the host firing `SessionStart` again with `source: "compact"`.
 
-### Claude Code SessionStart output
+A subagent hook adds only the host-owned worker identity fields:
 
-Claude's managed `SessionStart` command reads its event input from stdin and
-writes exactly this JSON object to stdout on successful preflight:
+```json
+{
+  "session_id": "session-01",
+  "cwd": ".",
+  "hook_event_name": "SubagentStart",
+  "agent_id": "agent-01",
+  "agent_type": "reviewer"
+}
+```
+
+Tree Ring derives a distinct worker identity from `agent_id` and `agent_type`;
+neither field is accepted as a store, project, capability, or coordinator
+identity. Both hosts may include transcript paths, model names, turn IDs, or
+other benign metadata. Tree Ring ignores those fields completely: it does not
+read, forward, log, persist, or include them in recall. Capability-bearing or
+root-selecting fields are rejected instead of ignored.
+
+### Codex and Claude Code lifecycle-hook output
+
+The managed command reads its event input from stdin and writes exactly one JSON
+object to stdout on successful preflight:
 
 ```json
 {
@@ -273,10 +294,41 @@ writes exactly this JSON object to stdout on successful preflight:
 }
 ```
 
-`additionalContext` contains only the safe context produced for the live
-session. It must not echo hook input, task prompts, receipt JSON, capabilities,
-or unredacted recalled content. The command fails without emitting a successful
-SessionStart object if receipt verification fails.
+For a worker, `hookEventName` is `SubagentStart`. `additionalContext` contains
+only the safe context produced for that live session or worker. It must not echo
+hook input, task prompts, receipt JSON, capabilities, or unredacted recalled
+content. The command fails without emitting a successful lifecycle object if
+receipt verification fails.
+
+### Codex and Claude Code automatic capture checkpoint
+
+`Stop` and `SubagentStop` events require the same host-owned session and worker
+identity fields plus `stop_hook_active`. Tree Ring ignores transcript paths and
+`last_assistant_message`; neither contributes to a candidate, checkpoint,
+receipt, or query. On the first stop attempt, the hook returns a non-error
+continuation decision:
+
+```json
+{
+  "decision": "block",
+  "reason": "Tree Ring automatic capture checkpoint ..."
+}
+```
+
+The reason directs the active agent to review only outcomes already in its
+working context and submit zero to three concise durable candidates through the
+strict `tree-ring capture` command. Zero is correct when nothing reusable
+occurred. `capture` fixes scope to `agent`; requires project, agent, workflow,
+session, idempotency, and `agent-checkpoint:` provenance; accepts only
+normal-sensitivity cambium, scar, or seed candidates; and passes through the
+existing coordinated write policy. `remember` and `evidence` remain available
+as explicit manual surfaces outside this automatic checkpoint.
+
+When the host re-runs the hook with `stop_hook_active: true`, Tree Ring emits an
+empty JSON object so the response can finish without a loop. Hook definitions
+are synchronous and bounded to ten seconds. Tree Ring does not register prompt,
+tool, or `SessionEnd` capture hooks, inspect a transcript, or run a background
+recorder.
 
 ### Pi JSON stdin request
 
@@ -328,7 +380,7 @@ claim a store, root, bridge fingerprint, harness identity, or receipt state are
 also rejected; those values come only from the local manifest and adapter.
 The Agent Zero descriptor is separate from stdin: it is accepted only through
 the installed plugin's internal absolute-path transport, never through a
-generic CLI option or an input field. Raw stdin and SessionStart input are
+generic CLI option or an input field. Raw stdin and lifecycle-hook input are
 transient: Tree Ring does not persist or log them, regardless of whether
 validation succeeds.
 

--- a/fixtures/harness-activation/claude-code.json
+++ b/fixtures/harness-activation/claude-code.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "harness_id": "claude-code",
-  "adapter_version": "1",
+  "adapter_version": "3",
   "marker_paths": [".claude"],
   "expected_bridge_paths": [
     ".claude/skills/tree-ring-memory/SKILL.md",

--- a/fixtures/harness-activation/codex.json
+++ b/fixtures/harness-activation/codex.json
@@ -1,10 +1,11 @@
 {
   "schema_version": 1,
   "harness_id": "codex",
-  "adapter_version": "1",
+  "adapter_version": "3",
   "marker_paths": [".codex"],
   "expected_bridge_paths": [
     ".agents/skills/tree-ring-memory/SKILL.md",
+    ".codex/hooks.json",
     "AGENTS.md"
   ],
   "expected_activation_state_before_proof": "configured-awaiting-proof",

--- a/plugins/tree-ring-memory/.claude-plugin/plugin.json
+++ b/plugins/tree-ring-memory/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "tree-ring-memory",
   "displayName": "Tree Ring Memory",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Local-first memory lifecycle, project bootstrap, and receipt-backed harness guidance for Claude Code using Tree Ring Memory v0.15+.",
   "author": {
     "name": "TerminallyLazy",
@@ -22,5 +22,6 @@
     "sqlite",
     "skills"
   ],
-  "skills": "./skills/"
+  "skills": "./skills/",
+  "hooks": "./hooks/claude-hooks.json"
 }

--- a/plugins/tree-ring-memory/PRIVACY.md
+++ b/plugins/tree-ring-memory/PRIVACY.md
@@ -2,15 +2,33 @@
 
 Effective August 23, 2026
 
-The Tree Ring Memory plugin is an instruction package for AI coding agents. It
-does not operate a hosted service, create a user account, collect analytics,
-send telemetry, or include a remote MCP server.
+The Tree Ring Memory repository plugin packages instructions and local
+lifecycle-hook registrations for AI coding agents. It does not operate a hosted
+service, create a user account, collect analytics, send telemetry, or include a
+remote MCP server.
 
-When an agent runs the separately installed Tree Ring Memory CLI, the CLI stores
-the memory content the user chooses in a local SQLite database under the
-configured Tree Ring root. The project does not receive that database or its
-contents. Data leaves the local environment only when the user or another tool
-explicitly exports, syncs, publishes, or otherwise transmits it.
+The repository hooks run only when a session or subagent starts or stops. They
+forward the host's lifecycle JSON through standard input to the separately
+installed Tree Ring Memory CLI and wait synchronously for at most 10 seconds.
+They do not register for user prompts, tool calls, or `SessionEnd`; persist hook
+input; capture prompts or transcripts; or run in the background. The lifecycle
+parser never inspects or persists `transcript_path`, `last_assistant_message`,
+prompts, or transcript content.
+
+Each stop event enforces one agent-mediated memory checkpoint. It asks the
+active agent to evaluate already-grounded work rather than deriving a summary
+from hook input. Only a concise, durable candidate classified as normal
+sensitivity may be written automatically with strict `tree-ring capture`.
+That command fixes agent scope, requires identity and provenance, tags the
+memory as automatic capture, and rejects sensitive content. If no candidate
+passes, no durable memory is created.
+
+When an agent runs an explicit command in the separately installed Tree Ring
+Memory CLI, including an identity-bound strict capture approved by the
+checkpoint gates, the CLI stores accepted memory content in a local SQLite
+database under the configured Tree Ring root. The project does not receive that
+database or its contents. Data leaves the local environment only when the user
+or another tool explicitly exports, syncs, publishes, or otherwise transmits it.
 
 The plugin instructs agents to avoid transcripts, credentials, secrets, private
 keys, raw chain-of-thought, and unnecessary sensitive personal data. It also

--- a/plugins/tree-ring-memory/README.md
+++ b/plugins/tree-ring-memory/README.md
@@ -1,16 +1,49 @@
 # Tree Ring Memory Agent Plugin
 
 This directory is the repository-distributed Tree Ring Memory plugin for
-ChatGPT/Codex and Claude Code. It packages instruction files only; the local
-Tree Ring Memory CLI remains the runtime and data owner.
+ChatGPT/Codex and Claude Code. It packages reviewed instructions plus thin
+lifecycle-hook registrations; the local Tree Ring Memory CLI remains the
+runtime and data owner.
 
-The Codex manifest is version `0.3.3`. The Claude Code manifest is version
-`0.3.2`. Both target Tree Ring Memory CLI `0.15.0` or newer and share the same
+The Codex manifest is version `0.3.4`. The Claude Code manifest is version
+`0.3.3`. Both target Tree Ring Memory CLI `0.15.0` or newer and share the same
 reviewed wrapper skill.
 
-The package does not run a background service, scrape chats, install hooks, or
-ship an MCP server. The active agent decides when a local, source-linked,
-privacy-safe memory action is warranted.
+The repository plugin registers exactly `SessionStart`, `SubagentStart`,
+`Stop`, and `SubagentStop`. Each hook forwards its event JSON directly to the
+local CLI and waits synchronously for at most 10 seconds. It does not register
+prompt, tool, compaction, or `SessionEnd` hooks; run a background service;
+scrape chats; or ship an MCP server.
+
+Session start covers startup, resume, and compaction rehydration when the host
+reports those sources. Subagent start gives each worker an independent,
+receipt-backed preflight. Codex requires review and trust of the installed hook
+definition before it runs. Claude Code loads the hook with the enabled plugin.
+
+Stop and subagent-stop enforce one agent-mediated memory checkpoint. The
+lifecycle parser uses only stable harness identity and project fields; it never
+inspects or persists `transcript_path`, `last_assistant_message`, prompts, or
+transcript content. The checkpoint asks the active agent to evaluate its
+already-grounded work. If and only if that evaluation yields a concise,
+durable, normal-sensitivity candidate, the agent automatically runs the exact
+strict `tree-ring capture` command template returned by the lifecycle handler.
+Strict capture fixes agent scope, requires identity and provenance, adds an
+automatic-capture tag, and rejects sensitive candidates. No candidate means no
+memory write. This is one bounded checkpoint, not a recorder or automatic
+summary of every turn.
+
+The hook wrapper resolves the Git project root when available, prefers that
+project's `.tree-ring/bin/tree-ring`, and otherwise uses `tree-ring` from
+`PATH`. It then invokes the shared lifecycle entry point with the project-local
+`.tree-ring` root. An unavailable or incompatible CLI is not active-harness
+proof and cannot be reported as a successful checkpoint or capture.
+
+When project activation has already installed the managed lifecycle definition
+in `.codex/hooks.json` or `.claude/settings.json`, that project definition owns
+recall and stop checkpoints. The marketplace wrapper detects the exact managed
+marker and exits without invoking the CLI, preventing duplicate context,
+receipts, checkpoint continuations, or capture attempts when the host merges
+project and plugin hooks.
 
 ## Install Or Update Tree Ring Memory
 
@@ -59,9 +92,19 @@ Ring Memory marketplace, and install Tree Ring Memory. When the repository is
 already open in Work mode or Codex, `.agents/plugins/marketplace.json` also
 exposes the repo-scoped package.
 
-OpenAI ZIP submission remains a separate public-directory channel. Its
-skills-only package intentionally includes the logo and composer icon but no
-`interface.screenshots` field.
+OpenAI ZIP submission remains a separate public-directory channel. Build that
+skills-only artifact explicitly instead of uploading the repository plugin:
+
+```bash
+python3 plugins/tree-ring-memory/packaging/build-codex-skills-only.py \
+  tree-ring-memory-codex-skills-only.zip
+```
+
+The generated ZIP has one `tree-ring-memory/` package root. It includes the
+skill, legal notices, logo, composer icon, and a dedicated skills-only manifest;
+it excludes lifecycle hooks, Claude commands and metadata, MCP servers, apps,
+and `interface.screenshots`. The repository plugin and public upload artifact
+are intentionally separate validation profiles.
 
 ## Install In Claude Code
 
@@ -98,6 +141,7 @@ into a false certification claim.
 
 ## Security
 
-This plugin ships instructions and local assets only. It includes no remote MCP
-server, webhooks, analytics, credentials, or networked runtime code. See
+This plugin ships instructions, local assets, and local lifecycle-hook
+registrations. It includes no remote MCP server, webhooks, analytics,
+credentials, or networked runtime code. See
 [PRIVACY.md](PRIVACY.md), [SECURITY.md](SECURITY.md), and [TERMS.md](TERMS.md).

--- a/plugins/tree-ring-memory/SECURITY.md
+++ b/plugins/tree-ring-memory/SECURITY.md
@@ -25,8 +25,19 @@ or personal data in a public issue.
 
 ## Data Handling
 
-This wrapper plugin contains guidance files only. It does not run a background
-service, include remote MCP servers, collect telemetry, or store credentials.
+This wrapper plugin contains guidance files and bounded local lifecycle-hook
+registrations. It does not run a background service, include remote MCP
+servers, collect telemetry, or store credentials. The hooks run only at
+`SessionStart`, `SubagentStart`, `Stop`, and `SubagentStop`, forward standard
+input directly to the local Tree Ring CLI, and do not persist prompts,
+transcripts, `last_assistant_message`, or hook input. They are synchronous,
+bounded to 10 seconds, and never run as a `SessionEnd` or background recorder.
+
+Stop hooks enforce one agent-mediated checkpoint. They may supply an exact
+strict `tree-ring capture` template only for concise durable candidates. Strict
+capture fixes agent scope, requires harness identity and provenance, accepts
+only normal sensitivity, and tags the result as automatic capture. A missing,
+sensitive, ambiguous, or ungrounded candidate must not be stored.
 
 Tree Ring Memory is designed for explicit agent-mediated memory actions. Store
 only concise decisions, lessons, warnings, and evidence references that are

--- a/plugins/tree-ring-memory/TERMS.md
+++ b/plugins/tree-ring-memory/TERMS.md
@@ -5,12 +5,13 @@ Effective August 23, 2026
 The Tree Ring Memory plugin is open-source software distributed under the MIT
 License. By using it, you agree to the license and these operational terms.
 
-The plugin provides agent instructions only. It is not a hosted memory service,
-backup service, access-control system, medical or legal record system, or
-guarantee that an AI host will follow every instruction. The user is responsible
-for choosing what to store, maintaining backups, controlling local filesystem
-access, reviewing agent actions, and complying with applicable policies and
-law.
+The repository plugin provides agent instructions and local lifecycle-hook
+registrations. The separate OpenAI upload artifact is skills-only. Neither is a
+hosted memory service, backup service, access-control system, medical or legal
+record system, or guarantee that an AI host will follow every instruction. The
+user is responsible for choosing what to store, maintaining backups, controlling
+local filesystem access, reviewing agent actions and hook trust, and complying
+with applicable policies and law.
 
 Tree Ring Memory is provided without warranty, including warranties of fitness,
 availability, accuracy, non-infringement, or data durability, to the maximum

--- a/plugins/tree-ring-memory/commands/tree-ring-capture.md
+++ b/plugins/tree-ring-memory/commands/tree-ring-capture.md
@@ -9,6 +9,43 @@ allowed-tools: ["Bash"]
 Capture only durable, useful memory. Do not store transcripts, secrets,
 credentials, raw chain-of-thought, or unverified claims as truth.
 
+## Lifecycle Stop Checkpoint
+
+`Stop` and `SubagentStop` hooks enforce one agent-mediated checkpoint. The hook
+never inspects or persists `transcript_path`, `last_assistant_message`, prompts,
+or transcript content. Evaluate the grounded work already in the active agent's
+context. If there is no durable, normal-sensitivity candidate, do not write a
+memory.
+
+For each qualifying candidate, use the exact identity-bound template returned
+by the lifecycle handler. Its strict shape is:
+
+```bash
+tree-ring --root .tree-ring capture "<concise summary>" \
+  --event-type <preference|decision|lesson|warning|correction|seed> \
+  --ring <cambium|scar|seed> \
+  --project <project> \
+  --agent-profile <profile> \
+  --workflow-id <workflow> \
+  --session-id <session> \
+  --operation-id auto-<checkpoint>-<1..3> \
+  --source-ref agent-checkpoint:<checkpoint> \
+  [--tag <tag>]
+```
+
+Do not invent or edit the supplied identity, checkpoint, operation, or source
+values. Strict capture fixes `scope=agent`, requires identity and provenance,
+adds the automatic-capture tag, and accepts normal sensitivity only. Use no more
+than three candidates in the single checkpoint. Never replace this with a raw
+transcript summary, `remember`, `evidence`, or an import.
+
+Use `cambium` for preferences, decisions, lessons, and corrections; `scar` for
+warnings; and `seed` for future work. A candidate still must be durable and
+grounded regardless of its ring.
+
+The manual command flow below remains available for an explicit user-directed
+capture outside a lifecycle checkpoint.
+
 Read project-local `.tree-ring/SKILL.md` and `.tree-ring/CLI.md` first when
 present. Follow the skill's Runtime Bootstrap And Updates procedure and confirm
 the selected project-local or global binary reports 0.15.0 or newer. Bootstrap

--- a/plugins/tree-ring-memory/hooks/claude-hook.sh
+++ b/plugins/tree-ring-memory/hooks/claude-hook.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+set -eu
+
+if command -v git >/dev/null 2>&1; then
+    project_root=$(git rev-parse --show-toplevel 2>/dev/null || true)
+    if [ -n "$project_root" ]; then
+        cd "$project_root"
+    fi
+fi
+
+# Project activation owns lifecycle recall and checkpoints when its managed hook
+# is present. The marketplace hook stands down to prevent duplicate handling.
+if [ -f .claude/settings.json ] && {
+    grep -Fq 'Tree Ring Memory managed lifecycle v2"' .claude/settings.json ||
+        grep -Fq 'Tree Ring Memory managed lifecycle v3"' .claude/settings.json
+}; then
+    exit 0
+fi
+
+tree_ring=tree-ring
+if [ -x .tree-ring/bin/tree-ring ]; then
+    tree_ring=.tree-ring/bin/tree-ring
+fi
+
+exec "$tree_ring" --root .tree-ring integrations hook --harness claude-code --input-json-stdin

--- a/plugins/tree-ring-memory/hooks/claude-hooks.json
+++ b/plugins/tree-ring-memory/hooks/claude-hooks.json
@@ -1,0 +1,57 @@
+{
+  "description": "Load bounded Tree Ring context at startup and enforce one agent-mediated memory checkpoint at stop.",
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/claude-hook.sh",
+            "args": [],
+            "timeout": 10,
+            "statusMessage": "Loading Tree Ring context"
+          }
+        ]
+      }
+    ],
+    "SubagentStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/claude-hook.sh",
+            "args": [],
+            "timeout": 10,
+            "statusMessage": "Loading Tree Ring worker context"
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/claude-hook.sh",
+            "args": [],
+            "timeout": 10,
+            "statusMessage": "Checking Tree Ring memory"
+          }
+        ]
+      }
+    ],
+    "SubagentStop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/claude-hook.sh",
+            "args": [],
+            "timeout": 10,
+            "statusMessage": "Checking Tree Ring worker memory"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/tree-ring-memory/hooks/codex-hook.sh
+++ b/plugins/tree-ring-memory/hooks/codex-hook.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+set -eu
+
+if command -v git >/dev/null 2>&1; then
+    project_root=$(git rev-parse --show-toplevel 2>/dev/null || true)
+    if [ -n "$project_root" ]; then
+        cd "$project_root"
+    fi
+fi
+
+# Project activation owns lifecycle recall and checkpoints when its managed hook
+# is present. The marketplace hook stands down to prevent duplicate handling.
+if [ -f .codex/hooks.json ] && {
+    grep -Fq 'Tree Ring Memory managed lifecycle v2"' .codex/hooks.json ||
+        grep -Fq 'Tree Ring Memory managed lifecycle v3"' .codex/hooks.json
+}; then
+    exit 0
+fi
+
+tree_ring=tree-ring
+if [ -x .tree-ring/bin/tree-ring ]; then
+    tree_ring=.tree-ring/bin/tree-ring
+fi
+
+exec "$tree_ring" --root .tree-ring integrations hook --harness codex --input-json-stdin

--- a/plugins/tree-ring-memory/hooks/codex-hooks.json
+++ b/plugins/tree-ring-memory/hooks/codex-hooks.json
@@ -1,0 +1,57 @@
+{
+  "description": "Load bounded Tree Ring context at startup and enforce one agent-mediated memory checkpoint at stop.",
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"${PLUGIN_ROOT}/hooks/codex-hook.sh\"",
+            "timeout": 10,
+            "statusMessage": "Loading Tree Ring context",
+            "additionalContextLimit": 6000
+          }
+        ]
+      }
+    ],
+    "SubagentStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"${PLUGIN_ROOT}/hooks/codex-hook.sh\"",
+            "timeout": 10,
+            "statusMessage": "Loading Tree Ring worker context",
+            "additionalContextLimit": 6000
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"${PLUGIN_ROOT}/hooks/codex-hook.sh\"",
+            "timeout": 10,
+            "statusMessage": "Checking Tree Ring memory",
+            "additionalContextLimit": 6000
+          }
+        ]
+      }
+    ],
+    "SubagentStop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"${PLUGIN_ROOT}/hooks/codex-hook.sh\"",
+            "timeout": 10,
+            "statusMessage": "Checking Tree Ring worker memory",
+            "additionalContextLimit": 6000
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/tree-ring-memory/packaging/build-codex-skills-only.py
+++ b/plugins/tree-ring-memory/packaging/build-codex-skills-only.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+"""Build the OpenAI upload artifact without repository lifecycle hooks."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from zipfile import ZIP_DEFLATED, ZipFile, ZipInfo
+
+
+PLUGIN = Path(__file__).resolve().parents[1]
+PROFILE = PLUGIN / "packaging" / "codex-skills-only"
+PACKAGE_ROOT = Path("tree-ring-memory")
+FIXED_TIMESTAMP = (2026, 1, 1, 0, 0, 0)
+
+
+def write_file(archive: ZipFile, source: Path, destination: Path) -> None:
+    info = ZipInfo(str(PACKAGE_ROOT / destination), FIXED_TIMESTAMP)
+    info.compress_type = ZIP_DEFLATED
+    info.external_attr = 0o100644 << 16
+    archive.writestr(info, source.read_bytes())
+
+
+def build(destination: Path) -> None:
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    with ZipFile(destination, "w") as archive:
+        write_file(
+            archive,
+            PROFILE / ".codex-plugin" / "plugin.json",
+            Path(".codex-plugin/plugin.json"),
+        )
+        for path in sorted((PLUGIN / "skills").rglob("*")):
+            if path.is_file():
+                write_file(archive, path, path.relative_to(PLUGIN))
+        for path in sorted((PLUGIN / "assets").rglob("*")):
+            if path.is_file():
+                write_file(archive, path, path.relative_to(PLUGIN))
+        for name in ("LICENSE", "PRIVACY.md", "SECURITY.md", "TERMS.md"):
+            write_file(archive, PLUGIN / name, Path(name))
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("output", type=Path, help="Destination ZIP path")
+    args = parser.parse_args()
+    build(args.output.resolve())
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/tree-ring-memory/packaging/codex-skills-only/.codex-plugin/plugin.json
+++ b/plugins/tree-ring-memory/packaging/codex-skills-only/.codex-plugin/plugin.json
@@ -22,7 +22,6 @@
     "skills"
   ],
   "skills": "./skills/",
-  "hooks": "./hooks/codex-hooks.json",
   "interface": {
     "displayName": "Tree Ring Memory",
     "shortDescription": "Local-first memory lifecycle guidance for Codex agents.",

--- a/plugins/tree-ring-memory/skills/tree-ring-memory/SKILL.md
+++ b/plugins/tree-ring-memory/skills/tree-ring-memory/SKILL.md
@@ -91,8 +91,10 @@ Use this sequence for meaningful project work:
    changed and defer to current source files, tests, policies, and user input.
 4. Do the work. Do not write memory merely because a session is active.
 5. At a natural checkpoint or closeout, capture only durable decisions,
-   corrections, validated lessons, warnings, or future seeds. Never store raw
-   transcripts, secrets, or sensitive data.
+   corrections, validated lessons, warnings, preferences, or future seeds.
+   Never store raw transcripts, secrets, or sensitive data. Repository
+   lifecycle integrations enforce one agent-mediated checkpoint at `Stop` or
+   `SubagentStop`; they do not derive memory from hook payloads.
 6. Observe the command result and report the actual outcome. A proposed memory,
    dry run, bridge file, or generated marker is not proof that a durable write,
    sync, activation, correction, or deletion occurred.
@@ -484,6 +486,23 @@ Tree Ring Memory does not autonomously scrape chats or write durable memory in
 the background. The active agent is responsible for deciding when a Tree Ring
 command is warranted, then calling the CLI deliberately.
 
+Repository lifecycle integrations register exactly `SessionStart`,
+`SubagentStart`, `Stop`, and `SubagentStop`. Start events perform bounded recall.
+Each stop event enforces one synchronous, agent-mediated memory checkpoint. The
+hook parser uses stable harness identity and project fields only; it never
+inspects or persists `transcript_path`, `last_assistant_message`, prompts, or
+transcript content. It does not register a prompt, tool, or `SessionEnd` hook.
+
+At the checkpoint, evaluate the grounded work already in your context. If there
+are no durable candidates, finish without a memory write. For up to three
+concise candidates that are durable, source-grounded, and normal sensitivity,
+automatically run the exact strict `tree-ring capture` command template supplied
+by the lifecycle handler. Do not edit its project, agent, workflow, session,
+checkpoint, operation, or source identity fields. Strict capture fixes
+`scope=agent`, adds the automatic-capture tag, and rejects sensitive content.
+Never substitute `remember`, `evidence`, an import, or a transcript summary for
+that checkpoint command.
+
 Use bridge files only to discover Tree Ring and its command reference:
 
 - project-level bridges should point to `.tree-ring/SKILL.md` and
@@ -513,7 +532,8 @@ Never keep known-wrong memory merely because it was previously recalled.
 
 ## Closeout Habit
 
-At the end of meaningful work, ask:
+At the end of meaningful work, or when a stop hook requests the single
+agent-mediated checkpoint, ask:
 
 - What did we decide?
 - What did we learn?
@@ -522,4 +542,6 @@ At the end of meaningful work, ask:
 - Is there a future seed worth revisiting?
 - Is any memory sensitive and better left unstored?
 
-Only remember the answers that will materially improve future work.
+Only remember the answers that will materially improve future work and pass the
+normal-sensitivity gate. During a lifecycle checkpoint, use only the supplied
+strict `tree-ring capture` template.

--- a/scripts/validate-plugin-packages.py
+++ b/scripts/validate-plugin-packages.py
@@ -4,12 +4,20 @@
 from __future__ import annotations
 
 import json
+import os
+import subprocess
+import sys
+import tempfile
 from pathlib import Path
 from typing import Any
+from zipfile import ZipFile
 
 
 ROOT = Path(__file__).resolve().parents[1]
 PLUGIN = ROOT / "plugins" / "tree-ring-memory"
+CODEX_SKILLS_ONLY = PLUGIN / "packaging" / "codex-skills-only"
+CODEX_SKILLS_BUILDER = PLUGIN / "packaging" / "build-codex-skills-only.py"
+LIFECYCLE_EVENTS = {"SessionStart", "SubagentStart", "Stop", "SubagentStop"}
 UNSAFE_TOKEN_EXPORT = "export TREE_RING_COORDINATOR_TOKEN='<"
 CANONICAL_ISSUES = "https://github.com/TerminallyLazy/Tree-Ring-Memory/issues"
 CANONICAL_ADVISORY = "https://github.com/TerminallyLazy/Tree-Ring-Memory/security/advisories/new"
@@ -60,10 +68,11 @@ def validate_codex() -> None:
 
     manifest = load_json(PLUGIN / ".codex-plugin" / "plugin.json")
     require(manifest.get("name") == "tree-ring-memory", "Codex manifest name is stale")
-    require(manifest.get("version") == "0.3.3", "Codex manifest version is stale")
+    require(manifest.get("version") == "0.3.4", "Codex manifest version is stale")
     require(manifest.get("skills") == "./skills/", "Codex skills path is stale")
-    for unsupported in ("mcpServers", "apps", "hooks"):
-        require(unsupported not in manifest, f"skills-only Codex plugin must not declare {unsupported}")
+    require(manifest.get("hooks") == "./hooks/codex-hooks.json", "Codex lifecycle hook path is stale")
+    for unsupported in ("mcpServers", "apps"):
+        require(unsupported not in manifest, f"repository Codex plugin must not declare {unsupported}")
     interface = manifest.get("interface")
     require(isinstance(interface, dict), "Codex interface metadata is required")
     require("screenshots" not in interface, "skills-only Codex ZIP must not declare screenshots")
@@ -72,11 +81,18 @@ def validate_codex() -> None:
         require(isinstance(asset, str) and asset.startswith("./assets/"), f"Codex {asset_key} path is invalid")
         require((PLUGIN / asset).is_file(), f"Codex {asset_key} asset is missing")
 
+    validate_hook_config(
+        PLUGIN / "hooks" / "codex-hooks.json",
+        command='"${PLUGIN_ROOT}/hooks/codex-hook.sh"',
+        expect_exec_form=False,
+    )
+    validate_hook_script(PLUGIN / "hooks" / "codex-hook.sh", "codex")
+
 
 def validate_claude() -> None:
     marketplace = load_json(ROOT / ".claude-plugin" / "marketplace.json")
     require(marketplace.get("name") == "tree-ring-memory", "Claude marketplace name is stale")
-    require(marketplace.get("version") == "0.3.2", "Claude marketplace version is stale")
+    require(marketplace.get("version") == "0.3.3", "Claude marketplace version is stale")
     require(isinstance(marketplace.get("owner"), dict), "Claude marketplace owner is required")
     entries = marketplace.get("plugins")
     require(isinstance(entries, list) and len(entries) == 1, "Claude marketplace must contain one plugin")
@@ -89,6 +105,7 @@ def validate_claude() -> None:
     require(manifest.get("name") == "tree-ring-memory", "Claude manifest name is stale")
     require(manifest.get("version") == marketplace.get("version"), "Claude versions are not synchronized")
     require(manifest.get("skills") == "./skills/", "Claude skills path is stale")
+    require(manifest.get("hooks") == "./hooks/claude-hooks.json", "Claude lifecycle hook path is stale")
 
     expected_commands = {
         "tree-ring-audit.md",
@@ -101,6 +118,188 @@ def validate_claude() -> None:
     }
     actual_commands = {path.name for path in (PLUGIN / "commands").glob("*.md")}
     require(actual_commands == expected_commands, "Claude command package is incomplete")
+
+    validate_hook_config(
+        PLUGIN / "hooks" / "claude-hooks.json",
+        command="${CLAUDE_PLUGIN_ROOT}/hooks/claude-hook.sh",
+        expect_exec_form=True,
+    )
+    validate_hook_script(PLUGIN / "hooks" / "claude-hook.sh", "claude-code")
+
+
+def validate_hook_config(path: Path, *, command: str, expect_exec_form: bool) -> None:
+    config = load_json(path)
+    events = config.get("hooks")
+    require(isinstance(events, dict), f"{path.relative_to(ROOT)} hooks object is required")
+    require(set(events) == LIFECYCLE_EVENTS, f"{path.relative_to(ROOT)} must register the exact lifecycle contract")
+
+    for event in sorted(LIFECYCLE_EVENTS):
+        groups = events[event]
+        require(isinstance(groups, list) and len(groups) == 1, f"{path.relative_to(ROOT)} {event} group is invalid")
+        require("matcher" not in groups[0], f"{path.relative_to(ROOT)} {event} must handle every start source")
+        handlers = groups[0].get("hooks")
+        require(isinstance(handlers, list) and len(handlers) == 1, f"{path.relative_to(ROOT)} {event} handler is invalid")
+        handler = handlers[0]
+        require(handler.get("type") == "command", f"{path.relative_to(ROOT)} {event} must use a command hook")
+        require(handler.get("command") == command, f"{path.relative_to(ROOT)} {event} command is stale")
+        require(handler.get("timeout") == 10, f"{path.relative_to(ROOT)} {event} timeout must remain bounded")
+        require(handler.get("async") in (None, False), f"{path.relative_to(ROOT)} {event} must not run in the background")
+        if expect_exec_form:
+            require(handler.get("args") == [], f"{path.relative_to(ROOT)} {event} must use safe exec form")
+        else:
+            require("args" not in handler, f"{path.relative_to(ROOT)} {event} uses unsupported Codex args")
+            require(
+                handler.get("additionalContextLimit") == 6000,
+                f"{path.relative_to(ROOT)} {event} context limit is stale",
+            )
+
+
+def validate_hook_script(path: Path, harness: str) -> None:
+    text = path.read_text(encoding="utf-8")
+    require(os.access(path, os.X_OK), f"{path.relative_to(ROOT)} must be executable")
+    require(".tree-ring/bin/tree-ring" in text, f"{path.relative_to(ROOT)} must prefer the project-local CLI")
+    require("git rev-parse --show-toplevel" in text, f"{path.relative_to(ROOT)} must resolve the project root")
+    managed_hook = ".codex/hooks.json" if harness == "codex" else ".claude/settings.json"
+    require(managed_hook in text, f"{path.relative_to(ROOT)} must detect the project-managed hook")
+    for version in (2, 3):
+        require(
+            f'Tree Ring Memory managed lifecycle v{version}"' in text,
+            f"{path.relative_to(ROOT)} must recognize managed lifecycle v{version}",
+        )
+    require(
+        text.index(managed_hook) < text.index('exec "$tree_ring"'),
+        f"{path.relative_to(ROOT)} must enforce ownership before invoking the CLI",
+    )
+    require(
+        f'--root .tree-ring integrations hook --harness {harness} --input-json-stdin' in text,
+        f"{path.relative_to(ROOT)} does not invoke the {harness} lifecycle entry point",
+    )
+    require("PLUGIN_DATA" not in text, f"{path.relative_to(ROOT)} must not persist lifecycle input")
+    require("CLAUDE_PLUGIN_DATA" not in text, f"{path.relative_to(ROOT)} must not persist lifecycle input")
+    require(">>" not in text and "tee " not in text, f"{path.relative_to(ROOT)} must not append lifecycle input")
+
+    events = {
+        "SessionStart": b'{"hook_event_name":"SessionStart","session_id":"validation-session"}\n',
+        "SubagentStart": b'{"hook_event_name":"SubagentStart","session_id":"validation-session","agent_id":"worker-1","agent_type":"worker"}\n',
+        "Stop": b'{"hook_event_name":"Stop","session_id":"validation-session","stop_hook_active":false,"transcript_path":"/private/transcript.jsonl","last_assistant_message":"must remain opaque"}\n',
+        "SubagentStop": b'{"hook_event_name":"SubagentStop","session_id":"validation-session","agent_id":"worker-1","agent_type":"worker","transcript_path":"/private/worker.jsonl","last_assistant_message":"must remain opaque"}\n',
+    }
+    with tempfile.TemporaryDirectory() as temporary:
+        project = Path(temporary)
+        cli = project / ".tree-ring" / "bin" / "tree-ring"
+        cli.parent.mkdir(parents=True)
+        cli.write_text(
+            "#!/bin/sh\n"
+            "printf '%s\\n' \"$@\" > \"$TREE_RING_TEST_ARGS\"\n"
+            "cat > \"$TREE_RING_TEST_STDIN\"\n"
+            "printf '%s\\n' '{\"hookSpecificOutput\":{\"additionalContext\":\"validated\"}}'\n",
+            encoding="utf-8",
+        )
+        cli.chmod(0o755)
+        args_capture = project / "args"
+        stdin_capture = project / "stdin"
+        environment = os.environ.copy()
+        environment["TREE_RING_TEST_ARGS"] = str(args_capture)
+        environment["TREE_RING_TEST_STDIN"] = str(stdin_capture)
+        for event_name in sorted(LIFECYCLE_EVENTS):
+            event = events[event_name]
+            result = subprocess.run(
+                [str(path)],
+                cwd=project,
+                env=environment,
+                input=event,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                check=True,
+            )
+            require(stdin_capture.read_bytes() == event, f"{path.relative_to(ROOT)} changed {event_name} JSON on stdin")
+            require(
+                args_capture.read_text(encoding="utf-8").splitlines()
+                == ["--root", ".tree-ring", "integrations", "hook", "--harness", harness, "--input-json-stdin"],
+                f"{path.relative_to(ROOT)} passed unexpected lifecycle arguments",
+            )
+            require(b"validated" in result.stdout, f"{path.relative_to(ROOT)} did not forward CLI output")
+            args_capture.unlink()
+            stdin_capture.unlink()
+
+        managed_path = project / managed_hook
+        managed_path.parent.mkdir(parents=True, exist_ok=True)
+        for version in (2, 3):
+            managed_path.write_text(
+                f'{{"description":"Tree Ring Memory managed lifecycle v{version}"}}\n',
+                encoding="utf-8",
+            )
+            duplicate = subprocess.run(
+                [str(path)],
+                cwd=project,
+                env=environment,
+                input=events["Stop"],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                check=True,
+            )
+            require(duplicate.stdout == b"", f"{path.relative_to(ROOT)} emitted duplicate v{version} context")
+            require(not args_capture.exists(), f"{path.relative_to(ROOT)} invoked the CLI for managed v{version}")
+            require(not stdin_capture.exists(), f"{path.relative_to(ROOT)} persisted managed v{version} input")
+
+        managed_path.write_text(
+            '{"description":"Tree Ring Memory managed lifecycle v4"}\n',
+            encoding="utf-8",
+        )
+        unsupported = subprocess.run(
+            [str(path)],
+            cwd=project,
+            env=environment,
+            input=events["SessionStart"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=True,
+        )
+        require(args_capture.exists(), f"{path.relative_to(ROOT)} incorrectly accepted managed lifecycle v4")
+        require(stdin_capture.read_bytes() == events["SessionStart"], f"{path.relative_to(ROOT)} dropped v4 fallback input")
+        require(b"validated" in unsupported.stdout, f"{path.relative_to(ROOT)} did not run the v4 fallback")
+
+
+def validate_codex_skills_only() -> None:
+    repository_manifest = load_json(PLUGIN / ".codex-plugin" / "plugin.json")
+    skills_manifest = load_json(CODEX_SKILLS_ONLY / ".codex-plugin" / "plugin.json")
+    expected_manifest = dict(repository_manifest)
+    expected_manifest.pop("hooks", None)
+    require(skills_manifest == expected_manifest, "skills-only Codex manifest drifted from repository metadata")
+    for unsupported in ("mcpServers", "apps", "hooks"):
+        require(unsupported not in skills_manifest, f"skills-only Codex ZIP must not declare {unsupported}")
+    require("screenshots" not in skills_manifest.get("interface", {}), "skills-only Codex ZIP must not declare screenshots")
+
+    with tempfile.TemporaryDirectory() as temporary:
+        first = Path(temporary) / "first.zip"
+        second = Path(temporary) / "second.zip"
+        for destination in (first, second):
+            subprocess.run([sys.executable, str(CODEX_SKILLS_BUILDER), str(destination)], check=True)
+        require(first.read_bytes() == second.read_bytes(), "skills-only Codex ZIP must be deterministic")
+        with ZipFile(first) as archive:
+            names = set(archive.namelist())
+            prefix = "tree-ring-memory/"
+            require(names and all(name.startswith(prefix) for name in names), "skills-only Codex ZIP needs one package root")
+            manifest_name = prefix + ".codex-plugin/plugin.json"
+            require(manifest_name in names, "skills-only Codex ZIP manifest is missing")
+            built_manifest = json.loads(archive.read(manifest_name))
+            require(built_manifest == skills_manifest, "skills-only Codex ZIP manifest is stale")
+            require(
+                not any(
+                    marker in name
+                    for name in names
+                    for marker in ("/hooks/", "/commands/", "/.claude-plugin/", "/packaging/")
+                ),
+                "skills-only Codex ZIP contains repository-only components",
+            )
+            require(
+                prefix + "skills/tree-ring-memory/SKILL.md" in names,
+                "skills-only Codex ZIP is missing its skill",
+            )
+            require(
+                prefix + "assets/tree-ring-memory-logo.png" in names,
+                "skills-only Codex ZIP is missing its declared assets",
+            )
 
 
 def validate_shared_contract() -> None:
@@ -145,6 +344,55 @@ def validate_shared_contract() -> None:
             "--root .tree-ring init",
         ],
     )
+    require_markers(
+        PLUGIN / "README.md",
+        [
+            "SessionStart`, `SubagentStart`, `Stop`, and `SubagentStop",
+            "one agent-mediated memory checkpoint",
+            "never inspects or persists `transcript_path`, `last_assistant_message`",
+            "strict `tree-ring capture` command template",
+            "normal-sensitivity candidate",
+            "at most 10 seconds",
+            "does not register prompt, tool, compaction, or `SessionEnd` hooks",
+        ],
+    )
+    require_markers(
+        PLUGIN / "PRIVACY.md",
+        [
+            "one agent-mediated memory checkpoint",
+            "never inspects or persists `transcript_path`, `last_assistant_message`",
+            "normal sensitivity",
+            "strict `tree-ring capture`",
+        ],
+    )
+    require_markers(
+        PLUGIN / "SECURITY.md",
+        [
+            "`SessionStart`, `SubagentStart`, `Stop`, and `SubagentStop`",
+            "never run as a `SessionEnd` or background recorder",
+            "strict `tree-ring capture`",
+            "accepts only normal sensitivity",
+        ],
+    )
+    require_markers(
+        skill,
+        [
+            "one synchronous, agent-mediated memory checkpoint",
+            "never inspects or persists `transcript_path`, `last_assistant_message`",
+            "up to three concise candidates",
+            "strict `tree-ring capture` command template",
+        ],
+    )
+    require_markers(
+        PLUGIN / "commands" / "tree-ring-capture.md",
+        [
+            "## Lifecycle Stop Checkpoint",
+            "tree-ring --root .tree-ring capture",
+            "--operation-id auto-<checkpoint>-<1..3>",
+            "--source-ref agent-checkpoint:<checkpoint>",
+            "accepts normal sensitivity only",
+        ],
+    )
     require((ROOT / "scripts" / "certify-tree-ring.sh").is_file(), "source certification script is missing")
     require(not (PLUGIN / "scripts" / "certify-tree-ring.sh").exists(), "source certification suite must not be bundled")
     for filename in ("LICENSE", "PRIVACY.md", "SECURITY.md", "TERMS.md", "README.md"):
@@ -177,9 +425,10 @@ def validate_shared_contract() -> None:
 
 def main() -> None:
     validate_codex()
+    validate_codex_skills_only()
     validate_claude()
     validate_shared_contract()
-    print("Tree Ring Memory Codex and Claude plugin packages validated")
+    print("Tree Ring Memory repository plugins and Codex skills-only ZIP validated")
 
 
 if __name__ == "__main__":

--- a/skills/tree-ring-memory/SKILL.md
+++ b/skills/tree-ring-memory/SKILL.md
@@ -205,6 +205,24 @@ Evidence outcome mapping:
 - `deferred`: seed for promising unresolved options
 - `observed`: outer-ring evaluation result
 
+## Automatic Capture Checkpoint
+
+Maintained Codex and Claude bridges enforce one agent-mediated checkpoint at
+`Stop` and `SubagentStop`; the Agent Zero plugin injects the same requirement
+through its native prompt lifecycle. Review only durable outcomes already in
+working context and select zero to three normal-sensitivity candidates. Zero is
+correct for transient planning, duplicates, unsupported claims, or work with no
+reusable result.
+
+Use the lifecycle-supplied strict `tree-ring capture` command for preferences,
+decisions, validated lessons, warnings, corrections, and future seeds. It fixes
+scope to `agent`, requires project and worker identity, uses distinct indexed
+operation IDs plus `agent-checkpoint:` provenance, and permits only cambium,
+scar, or seed. Use only `tree-ring capture` for this automatic checkpoint;
+manual `remember` and `evidence` remain separate surfaces. Never store raw prompts,
+transcripts, tool logs, secrets, or sensitive data; never invent filler memory;
+and never start a background recorder.
+
 ## Memory Quality Gates
 
 Use these gates before relying on or writing memory.


### PR DESCRIPTION
## Summary
- add native Codex and Claude lifecycle hook adapters for session and subagent start/stop
- recall bounded, receipt-backed context at start and issue a single agent-mediated capture checkpoint at stop
- add strict agent-scoped capture constraints that reject sensitive data, transcripts, unsupported rings, and more than three candidates
- package validated Codex and Claude plugin hook surfaces and bump Tree Ring Memory to 0.15.5

## Verification
- cargo fmt --all -- --check
- cargo test --workspace
- cargo clippy --workspace --all-targets -- -D warnings
- python3 scripts/validate-plugin-packages.py
- sh scripts/certify-tree-ring.sh
- native Linux x86_64 and aarch64 Docker builds validated on Bookworm with max GLIBC 2.34

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR adds native lifecycle hooks for Codex and Claude that perform bounded automatic memory capture at session and subagent start/stop events. Start hooks execute receipt-backed recall, while stop hooks enforce a single agent-mediated checkpoint allowing zero to three strict, normal-sensitivity automatic captures through a new `tree-ring capture` command. The implementation includes lifecycle event parsing that deliberately ignores transcripts and sensitive fields, agent-scoped capture constraints that reject sensitive data and unsupported rings, updated plugin manifests bumping Tree Ring Memory to version 0.15.5, and comprehensive hook validation ensuring the lifecycle bridge never scrapes transcripts or runs background recorders.

⏱️ Estimated Review Time: 1-3 hours

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `README.md` |
| 2 | `Cargo.toml` |
| 3 | `Cargo.lock` |
| 4 | `crates/tree-ring-memory-cli/Cargo.toml` |
| 5 | `crates/tree-ring-memory-cli/src/actions/remember.rs` |
| 6 | `crates/tree-ring-memory-cli/src/activation/lifecycle.rs` |
| 7 | `crates/tree-ring-memory-cli/src/activation/preflight.rs` |
| 8 | `crates/tree-ring-memory-cli/src/activation/adapters.rs` |
| 9 | `crates/tree-ring-memory-cli/src/activation/bridge.rs` |
| 10 | `crates/tree-ring-memory-cli/src/activation/manifest.rs` |
| 11 | `crates/tree-ring-memory-cli/src/activation/mod.rs` |
| 12 | `crates/tree-ring-memory-cli/src/activation/launcher.rs` |
| 13 | `crates/tree-ring-memory-cli/src/main.rs` |
| 14 | `crates/tree-ring-memory-cli/src/agent_awareness.rs` |
| 15 | `crates/tree-ring-memory-cli/tests/harness_activation_acceptance.rs` |
| 16 | `plugins/tree-ring-memory/hooks/codex-hooks.json` |
| 17 | `plugins/tree-ring-memory/hooks/codex-hook.sh` |
| 18 | `plugins/tree-ring-memory/hooks/claude-hooks.json` |
| 19 | `plugins/tree-ring-memory/hooks/claude-hook.sh` |
| 20 | `plugins/tree-ring-memory/commands/tree-ring-capture.md` |
| 21 | `plugins/tree-ring-memory/.codex-plugin/plugin.json` |
| 22 | `plugins/tree-ring-memory/.claude-plugin/plugin.json` |
| 23 | `plugins/tree-ring-memory/README.md` |
| 24 | `plugins/tree-ring-memory/PRIVACY.md` |
| 25 | `plugins/tree-ring-memory/SECURITY.md` |
| 26 | `plugins/tree-ring-memory/TERMS.md` |
| 27 | `plugins/tree-ring-memory/skills/tree-ring-memory/SKILL.md` |
| 28 | `plugins/tree-ring-memory/packaging/build-codex-skills-only.py` |
| 29 | `plugins/tree-ring-memory/packaging/codex-skills-only/.codex-plugin/plugin.json` |
| 30 | `skills/tree-ring-memory/SKILL.md` |
| 31 | `docs/integrations/agent-skill.md` |
| 32 | `docs/launch/tree-ring-memory-framework.md` |
| 33 | `docs/protocol/harness-activation.md` |
| 34 | `fixtures/harness-activation/codex.json` |
| 35 | `fixtures/harness-activation/claude-code.json` |
| 36 | `.claude-plugin/marketplace.json` |
| 37 | `scripts/validate-plugin-packages.py` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added lifecycle hooks for session and subagent start/stop events in Codex and Claude Code.
  * Added strict, privacy-filtered automatic memory capture with up to three durable candidates per checkpoint.
  * Added a `tree-ring capture` command and lifecycle hook integration command.
  * Added a skills-only Codex package for environments without lifecycle hooks.
* **Documentation**
  * Updated setup, privacy, security, and usage guidance for lifecycle capture and hook behavior.
* **Maintenance**
  * Updated package versions and expanded validation for hooks and distributable packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->