### PR TITLE
fix: match Codex plugin hooks to supported event fields

### DIFF
--- a/plugins/tree-ring-memory/.codex-plugin/plugin.json
+++ b/plugins/tree-ring-memory/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "tree-ring-memory",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "description": "Local-first memory lifecycle, project bootstrap, and receipt-backed harness guidance for coding agents using Tree Ring Memory v0.15+.",
   "author": {
     "name": "TerminallyLazy",

--- a/plugins/tree-ring-memory/README.md
+++ b/plugins/tree-ring-memory/README.md
@@ -5,7 +5,7 @@ ChatGPT/Codex and Claude Code. It packages reviewed instructions plus thin
 lifecycle-hook registrations; the local Tree Ring Memory CLI remains the
 runtime and data owner.
 
-The Codex manifest is version `0.3.5`. The Claude Code manifest is version
+The Codex manifest is version `0.3.6`. The Claude Code manifest is version
 `0.3.4`. Both share the same reviewed wrapper skill. Manual guidance supports
 CLI `0.15.0` or newer; the lifecycle hooks require CLI `0.15.6` or newer for
 project-local runtime resolution and cross-session recall.

--- a/plugins/tree-ring-memory/hooks/codex-hooks.json
+++ b/plugins/tree-ring-memory/hooks/codex-hooks.json
@@ -34,8 +34,7 @@
             "type": "command",
             "command": "\"${PLUGIN_ROOT}/hooks/codex-hook.sh\"",
             "timeout": 10,
-            "statusMessage": "Checking Tree Ring memory",
-            "additionalContextLimit": 6000
+            "statusMessage": "Checking Tree Ring memory"
           }
         ]
       }
@@ -47,8 +46,7 @@
             "type": "command",
             "command": "\"${PLUGIN_ROOT}/hooks/codex-hook.sh\"",
             "timeout": 10,
-            "statusMessage": "Checking Tree Ring worker memory",
-            "additionalContextLimit": 6000
+            "statusMessage": "Checking Tree Ring worker memory"
           }
         ]
       }

--- a/plugins/tree-ring-memory/packaging/codex-skills-only/.codex-plugin/plugin.json
+++ b/plugins/tree-ring-memory/packaging/codex-skills-only/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "tree-ring-memory",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "description": "Local-first memory lifecycle, project bootstrap, and receipt-backed harness guidance for coding agents using Tree Ring Memory v0.15+.",
   "author": {
     "name": "TerminallyLazy",

--- a/scripts/validate-plugin-packages.py
+++ b/scripts/validate-plugin-packages.py
@@ -68,7 +68,7 @@ def validate_codex() -> None:
 
     manifest = load_json(PLUGIN / ".codex-plugin" / "plugin.json")
     require(manifest.get("name") == "tree-ring-memory", "Codex manifest name is stale")
-    require(manifest.get("version") == "0.3.5", "Codex manifest version is stale")
+    require(manifest.get("version") == "0.3.6", "Codex manifest version is stale")
     require(manifest.get("skills") == "./skills/", "Codex skills path is stale")
     require(manifest.get("hooks") == "./hooks/codex-hooks.json", "Codex lifecycle hook path is stale")
     for unsupported in ("mcpServers", "apps"):
@@ -149,7 +149,7 @@ def validate_hook_config(path: Path, *, command: str, expect_exec_form: bool) ->
         else:
             require("args" not in handler, f"{path.relative_to(ROOT)} {event} uses unsupported Codex args")
             require(
-                handler.get("additionalContextLimit") == 6000,
+                handler.get("additionalContextLimit") == (6000 if event in {"SessionStart", "SubagentStart"} else None),
                 f"{path.relative_to(ROOT)} {event} context limit is stale",
             )
 


### PR DESCRIPTION
Codex 0.151 reports warnings when a stop hook declares `additionalContextLimit`: only startup hooks can emit that context. Keep the limit on SessionStart and SubagentStart, remove it from Stop and SubagentStop, and bump the Codex plugin to 0.3.6 so installed caches refresh.

Validated with the repository package checks, including all four event forwarders and suppression when managed project hooks own the lifecycle. The warning was observed through the installed Codex host's `hooks/list` API. This changes plugin packaging only; CLI 0.15.6 remains the runtime release.

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR fixes a Codex 0.151 compatibility issue by removing the `additionalContextLimit` field from stop hooks (Stop and SubagentStop events) since only startup hooks can emit additional context. The field is correctly retained on SessionStart and SubagentStart hooks. The plugin version is bumped from 0.3.5 to 0.3.6 to refresh installed caches, and validation tests are updated to match the new hook configuration.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `plugins/tree-ring-memory/.codex-plugin/plugin.json` |
| 2 | `plugins/tree-ring-memory/packaging/codex-skills-only/.codex-plugin/plugin.json` |
| 3 | `plugins/tree-ring-memory/README.md` |
| 4 | `plugins/tree-ring-memory/hooks/codex-hooks.json` |
| 5 | `scripts/validate-plugin-packages.py` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->