### PR TITLE
Preserve native hooks in public plugin uploads

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,7 +5,7 @@
     "url": "https://github.com/TerminallyLazy"
   },
   "description": "Claude Code marketplace for Tree Ring Memory v0.15 verified bootstrap, lifecycle recall, strict automatic capture, and receipt-backed harness readiness.",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "plugins": [
     {
       "name": "tree-ring-memory",

--- a/README.md
+++ b/README.md
@@ -111,7 +111,8 @@ recall result count distinguishes a successful empty recall from a hook that
 has never run. CLI 0.15.6 repairs cross-session startup recall and generated
 hooks for project-local installs; see the
 [recall visibility and startup brief contract](docs/protocol/harness-activation.md#recall-visibility-and-startup-briefs).
-The skills-only public-directory plugin does not install lifecycle hooks.
+The current public-directory upload also includes native Codex lifecycle hooks;
+ordinary Chat hosts without the Codex hook runtime remain guidance-only.
 
 Default `init` creates the canonical project-local store and configures
 maintained adapters where new project-local bridge and manifest entries can be

--- a/plugins/tree-ring-memory/.claude-plugin/plugin.json
+++ b/plugins/tree-ring-memory/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "tree-ring-memory",
   "displayName": "Tree Ring Memory",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "Local-first memory lifecycle, project bootstrap, and receipt-backed harness guidance for Claude Code using Tree Ring Memory v0.15+.",
   "author": {
     "name": "TerminallyLazy",

--- a/plugins/tree-ring-memory/.codex-plugin/plugin.json
+++ b/plugins/tree-ring-memory/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "tree-ring-memory",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "description": "Local-first memory lifecycle, project bootstrap, and receipt-backed harness guidance for coding agents using Tree Ring Memory v0.15+.",
   "author": {
     "name": "TerminallyLazy",

--- a/plugins/tree-ring-memory/README.md
+++ b/plugins/tree-ring-memory/README.md
@@ -5,8 +5,8 @@ ChatGPT/Codex and Claude Code. It packages reviewed instructions plus thin
 lifecycle-hook registrations; the local Tree Ring Memory CLI remains the
 runtime and data owner.
 
-The Codex manifest is version `0.3.6`. The Claude Code manifest is version
-`0.3.4`. Both share the same reviewed wrapper skill. Manual guidance supports
+The Codex manifest is version `0.3.7`. The Claude Code manifest is version
+`0.3.5`. Both share the same reviewed wrapper skill. Manual guidance supports
 CLI `0.15.0` or newer; the lifecycle hooks require CLI `0.15.6` or newer for
 project-local runtime resolution and cross-session recall.
 
@@ -54,9 +54,8 @@ project and plugin hooks.
 
 `integrations status --verbose` reports the last validated recall's result
 count and query class. A zero-result receipt proves the check ran; it does not
-prove that useful context was found. A skills-only plugin installation has no
-automatic lifecycle hooks; enable the repository plugin or configure the
-project with the CLI to obtain them. A newly configured Codex hook still needs
+prove that useful context was found. Older skills-only packages omitted
+automatic lifecycle hooks. Current Git and public upload packages include them. A newly configured Codex hook still needs
 the host's trust flow and a new session before automatic execution can be
 verified.
 
@@ -116,10 +115,15 @@ python3 plugins/tree-ring-memory/packaging/build-codex-skills-only.py \
 ```
 
 The generated ZIP has one `tree-ring-memory/` package root. It includes the
-skill, legal notices, logo, composer icon, and a dedicated skills-only manifest;
-it excludes lifecycle hooks, Claude commands and metadata, MCP servers, apps,
-and `interface.screenshots`. The repository plugin and public upload artifact
-are intentionally separate validation profiles.
+skill, legal notices, logo, composer icon, manifest, and executable native Codex
+lifecycle hooks. The portal calls this route "Skills only" because it has no MCP
+server. It excludes Claude commands and metadata, MCP servers, apps, and
+`interface.screenshots`. Hooks need the Codex runtime, an available CLI, and host
+trust; ordinary Chat remains guidance-only. See [OpenAI packaging](https://developers.openai.com/plugins/build/plugins)
+and [submission compatibility](https://developers.openai.com/plugins/guides/submit-claude-plugin).
+Older scaffold validators that reject every `hooks` field do not represent this
+current contract; package checks verify the native hook schema, packaged bytes,
+and executable permissions.
 
 ## Install In Claude Code
 

--- a/plugins/tree-ring-memory/packaging/build-codex-skills-only.py
+++ b/plugins/tree-ring-memory/packaging/build-codex-skills-only.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Build the OpenAI upload artifact without repository lifecycle hooks."""
+"""Build the OpenAI skills-only upload, including native Codex lifecycle hooks."""
 
 from __future__ import annotations
 
@@ -17,7 +17,9 @@ FIXED_TIMESTAMP = (2026, 1, 1, 0, 0, 0)
 def write_file(archive: ZipFile, source: Path, destination: Path) -> None:
     info = ZipInfo(str(PACKAGE_ROOT / destination), FIXED_TIMESTAMP)
     info.compress_type = ZIP_DEFLATED
-    info.external_attr = 0o100644 << 16
+    info.create_system = 3
+    mode = 0o100755 if source.stat().st_mode & 0o111 else 0o100644
+    info.external_attr = mode << 16
     archive.writestr(info, source.read_bytes())
 
 
@@ -35,6 +37,9 @@ def build(destination: Path) -> None:
         for path in sorted((PLUGIN / "assets").rglob("*")):
             if path.is_file():
                 write_file(archive, path, path.relative_to(PLUGIN))
+        for name in ("codex-hooks.json", "codex-hook.sh"):
+            path = PLUGIN / "hooks" / name
+            write_file(archive, path, path.relative_to(PLUGIN))
         for name in ("LICENSE", "PRIVACY.md", "SECURITY.md", "TERMS.md"):
             write_file(archive, PLUGIN / name, Path(name))
 

--- a/plugins/tree-ring-memory/packaging/codex-skills-only/.codex-plugin/plugin.json
+++ b/plugins/tree-ring-memory/packaging/codex-skills-only/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "tree-ring-memory",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "description": "Local-first memory lifecycle, project bootstrap, and receipt-backed harness guidance for coding agents using Tree Ring Memory v0.15+.",
   "author": {
     "name": "TerminallyLazy",
@@ -44,5 +44,6 @@
     "brandColor": "#2F7D5C",
     "composerIcon": "./assets/tree-ring-memory-logo.png",
     "logo": "./assets/tree-ring-memory-logo.png"
-  }
+  },
+  "hooks": "./hooks/codex-hooks.json"
 }

--- a/plugins/tree-ring-memory/skills/tree-ring-memory/SKILL.md
+++ b/plugins/tree-ring-memory/skills/tree-ring-memory/SKILL.md
@@ -31,8 +31,8 @@ working directory by accident.
    this project. Otherwise check `command -v tree-ring` and run
    `tree-ring --version`.
 2. Read existing `<project-root>/.tree-ring/SKILL.md` and `CLI.md` when present.
-   Lifecycle hooks need CLI 0.15.6 or newer; a skills-only plugin package has no
-   automatic hooks. Use `integrations status --verbose` to inspect the last
+   Lifecycle hooks need CLI 0.15.6 or newer; older packages may omit
+   automatic hooks. Current Codex packages include them, including the public upload. Use `integrations status --verbose` to inspect the last
    recall count and query class, and distinguish no receipt from zero results.
 3. This package targets Tree Ring Memory CLI 0.15.0 or newer. If no compatible
    CLI is available and the user's request already authorizes Tree Ring setup,

--- a/scripts/validate-plugin-packages.py
+++ b/scripts/validate-plugin-packages.py
@@ -68,7 +68,7 @@ def validate_codex() -> None:
 
     manifest = load_json(PLUGIN / ".codex-plugin" / "plugin.json")
     require(manifest.get("name") == "tree-ring-memory", "Codex manifest name is stale")
-    require(manifest.get("version") == "0.3.6", "Codex manifest version is stale")
+    require(manifest.get("version") == "0.3.7", "Codex manifest version is stale")
     require(manifest.get("skills") == "./skills/", "Codex skills path is stale")
     require(manifest.get("hooks") == "./hooks/codex-hooks.json", "Codex lifecycle hook path is stale")
     for unsupported in ("mcpServers", "apps"):
@@ -92,7 +92,7 @@ def validate_codex() -> None:
 def validate_claude() -> None:
     marketplace = load_json(ROOT / ".claude-plugin" / "marketplace.json")
     require(marketplace.get("name") == "tree-ring-memory", "Claude marketplace name is stale")
-    require(marketplace.get("version") == "0.3.4", "Claude marketplace version is stale")
+    require(marketplace.get("version") == "0.3.5", "Claude marketplace version is stale")
     require(isinstance(marketplace.get("owner"), dict), "Claude marketplace owner is required")
     entries = marketplace.get("plugins")
     require(isinstance(entries, list) and len(entries) == 1, "Claude marketplace must contain one plugin")
@@ -264,9 +264,8 @@ def validate_codex_skills_only() -> None:
     repository_manifest = load_json(PLUGIN / ".codex-plugin" / "plugin.json")
     skills_manifest = load_json(CODEX_SKILLS_ONLY / ".codex-plugin" / "plugin.json")
     expected_manifest = dict(repository_manifest)
-    expected_manifest.pop("hooks", None)
     require(skills_manifest == expected_manifest, "skills-only Codex manifest drifted from repository metadata")
-    for unsupported in ("mcpServers", "apps", "hooks"):
+    for unsupported in ("mcpServers", "apps"):
         require(unsupported not in skills_manifest, f"skills-only Codex ZIP must not declare {unsupported}")
     require("screenshots" not in skills_manifest.get("interface", {}), "skills-only Codex ZIP must not declare screenshots")
 
@@ -288,10 +287,16 @@ def validate_codex_skills_only() -> None:
                 not any(
                     marker in name
                     for name in names
-                    for marker in ("/hooks/", "/commands/", "/.claude-plugin/", "/packaging/")
+                    for marker in ("/commands/", "/.claude-plugin/", "/packaging/")
                 ),
                 "skills-only Codex ZIP contains repository-only components",
             )
+            for hook_name in ("codex-hooks.json", "codex-hook.sh"):
+                archive_path = prefix + "hooks/" + hook_name
+                require(archive_path in names, "public upload is missing its native lifecycle hook")
+                require(archive.read(archive_path) == (PLUGIN / "hooks" / hook_name).read_bytes(), "public upload hook differs from the validated runtime hook")
+            hook_mode = archive.getinfo(prefix + "hooks/codex-hook.sh").external_attr >> 16
+            require(hook_mode & 0o111 != 0, "public upload hook script must remain executable")
             require(
                 prefix + "skills/tree-ring-memory/SKILL.md" in names,
                 "skills-only Codex ZIP is missing its skill",


### PR DESCRIPTION
The public upload builder previously stripped lifecycle hooks even though the current OpenAI submission contract supports native Codex command hooks. Include the canonical four-event hook configuration and executable script in the deterministic ZIP, validate its bytes and permissions, and correct shared guidance. Publish wrapper versions Codex 0.3.7 and Claude 0.3.5; the runtime remains 0.15.7.

Validation: core package checks and standalone Codex/Claude validators pass. Existing native lifecycle scripts are unchanged. Current contract: https://developers.openai.com/plugins/guides/submit-claude-plugin

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR modifies the public plugin upload builder to include native Codex lifecycle hooks that were previously stripped, aligning with the current OpenAI submission contract. The changes preserve executable hook scripts (`codex-hooks.json` and `codex-hook.sh`) with correct permissions in the deterministic ZIP package, update validation logic to verify hook bytes and permissions, and bump wrapper versions to Codex **0.3.7** and Claude **0.3.5**. Documentation is updated throughout to clarify that current public uploads include lifecycle hooks while ordinary Chat hosts without Codex runtime remain guidance-only.

⏱️ Estimated Review Time: 15-30 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `plugins/tree-ring-memory/packaging/build-codex-skills-only.py` |
| 2 | `scripts/validate-plugin-packages.py` |
| 3 | `plugins/tree-ring-memory/packaging/codex-skills-only/.codex-plugin/plugin.json` |
| 4 | `plugins/tree-ring-memory/.codex-plugin/plugin.json` |
| 5 | `plugins/tree-ring-memory/.claude-plugin/plugin.json` |
| 6 | `.claude-plugin/marketplace.json` |
| 7 | `plugins/tree-ring-memory/skills/tree-ring-memory/SKILL.md` |
| 8 | `plugins/tree-ring-memory/README.md` |
| 9 | `README.md` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Skills-only Codex packages now include native lifecycle hooks.
  - Packaged hooks retain executable permissions for automatic lifecycle behavior.

- **Documentation**
  - Updated setup guidance to explain lifecycle hook availability across current Codex packages and older skills-only packages.
  - Clarified requirements for using hooks, including supported runtimes and trust settings.
  - Updated package version information and distribution descriptions.

- **Quality Improvements**
  - Added package checks to verify hook contents, configuration, and executable permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->